### PR TITLE
Feat/core 13 observability

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -42,7 +42,7 @@ var BuildTime = "no-build-time"
 
 var CommitHash = "no-commit-hash"
 
-var Environment = "dev"
+var Environment = "no-env"
 
 func main() {
 	AppName = os.Getenv("APP_NAME")
@@ -53,6 +53,11 @@ func main() {
 	if BuildTime == "no-build-time" {
 		now := time.Now()
 		BuildTime = "not provided (now: " + now.Format(time.RFC3339) + ")"
+	}
+
+	Environment = os.Getenv("Environment")
+	if Environment == "" {
+		Environment = "no-env"
 	}
 
 	appMetadata := []zap.Field{


### PR DESCRIPTION
## Type of changes

- Feature
## Purpose

- Add the Environment attribute to the traces in the initOpenTelemetry function.
- Read the Environment attribute from the env flag.
## Additional Information

The env attribute is used to indicate whether the application is running in a dev or stage environment.
Currently, it defaults to dev via the global assignment var Environment = "dev".
This change adds support for including the attribute in trace data, but does not implement dynamic assignment logic.