### PR TITLE
[CORE 13] Add OTEL_COLLECTOR_URL and vector.enable to deploy, snapshot, and stage docker-compose configs

### DIFF
--- a/.deploy/dev/compose.yaml
+++ b/.deploy/dev/compose.yaml
@@ -12,6 +12,7 @@ services:
       HOST: "0.0.0.0"
       DATABASE_URL: postgres://postgres:password@postgres:5432/core_system?sslmode=disable
       MIGRATION_SOURCE: file:///app/migrations
+      OTEL_COLLECTOR_URL: 10.140.0.3:4317
     labels:
       - "vector.enable=true"
       - "traefik.enable=true"

--- a/.deploy/snapshot/compose.yaml
+++ b/.deploy/snapshot/compose.yaml
@@ -17,6 +17,7 @@ services:
       HOST: "0.0.0.0"
       DATABASE_URL: postgres://postgres:password@postgres:5432/core_system?sslmode=disable
       MIGRATION_SOURCE: file:///app/migrations
+      OTEL_COLLECTOR_URL: 10.140.0.3:4317
     
   postgres:
     image: postgres:latest

--- a/.deploy/snapshot/compose.yaml
+++ b/.deploy/snapshot/compose.yaml
@@ -18,6 +18,8 @@ services:
       DATABASE_URL: postgres://postgres:password@postgres:5432/core_system?sslmode=disable
       MIGRATION_SOURCE: file:///app/migrations
       OTEL_COLLECTOR_URL: 10.140.0.3:4317
+    labels:
+      - "vector.enable=true"
     
   postgres:
     image: postgres:latest

--- a/.deploy/stage/compose.yaml
+++ b/.deploy/stage/compose.yaml
@@ -18,6 +18,8 @@ services:
       DATABASE_URL: postgres://postgres:password@postgres:5432/core_system?sslmode=disable
       MIGRATION_SOURCE: file:///app/migrations
       OTEL_COLLECTOR_URL: 10.140.0.3:4317
+    labels:
+      - "vector.enable=true"
 
   postgres:
     image: postgres:latest

--- a/.deploy/stage/compose.yaml
+++ b/.deploy/stage/compose.yaml
@@ -17,6 +17,7 @@ services:
       HOST: "0.0.0.0"
       DATABASE_URL: postgres://postgres:password@postgres:5432/core_system?sslmode=disable
       MIGRATION_SOURCE: file:///app/migrations
+      OTEL_COLLECTOR_URL: 10.140.0.3:4317
 
   postgres:
     image: postgres:latest


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Added `OTEL_COLLECTOR_URL` environment variable
- Added `vector.enable=true` label to enable docker log forwarding via Vector


## Additional Information

This is a follow-up to the observability setup introduced in CORE-13. 

- `OTEL_COLLECTOR_URL` is set as a static environment variable in each `docker-compose.yml`. This ensures services send telemetry data to the designated OpenTelemetry collector.
- The `vector.enable: true` label was added under each service's `labels` section to allow Vector to pick up container logs and forward them appropriately.
