### PR TITLE
fix: add trace and recover to jwtMiddleware and rename to authMiddleware

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -132,6 +132,9 @@ func main() {
 	basicMiddleware := middleware.NewSet(traceMiddleware.RecoverMiddleware)
 	basicMiddleware = basicMiddleware.Append(traceMiddleware.TraceMiddleWare)
 
+	// Auth Middleware
+	authMiddleware := basicMiddleware.Append(jwtMiddleware.AuthenticateMiddleware)
+
 	// HTTP Server
 	mux := http.NewServeMux()
 
@@ -158,7 +161,7 @@ func main() {
 	mux.HandleFunc("POST /api/auth/logout", basicMiddleware.HandlerFunc(authHandler.Logout))
 
 	// User authenticated routes
-	mux.Handle("GET /api/users/me", jwtMiddleware.AuthenticateMiddleware(userHandler.GetMe))
+	mux.Handle("GET /api/users/me", authMiddleware.HandlerFunc(userHandler.GetMe))
 
 	// handle interrupt signal
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Add trace and recover to jwtMiddleware and rename to authMiddleware
- Fix the route of usage of jwtMiddleware