### PR TITLE
Fix: modify JWT claims structure to include Name and AvatarUrl

### DIFF
--- a/internal/handler.go
+++ b/internal/handler.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"

--- a/internal/jwt/service.go
+++ b/internal/jwt/service.go
@@ -56,9 +56,11 @@ func NewService(
 }
 
 type claims struct {
-	ID       uuid.UUID
-	Username string
-	Role     []string
+	ID        uuid.UUID
+	Username  string
+	Name      string
+	AvatarUrl string
+	Role      []string
 	jwt.RegisteredClaims
 }
 
@@ -73,9 +75,11 @@ func (s Service) New(ctx context.Context, user user.User) (string, error) {
 	username := user.Username.String
 
 	claims := &claims{
-		ID:       jwtID,
-		Username: username,
-		Role:     user.Role,
+		ID:        jwtID,
+		Username:  username,
+		Name:      user.Name.String,
+		AvatarUrl: user.AvatarUrl.String,
+		Role:      user.Role,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    Issuer,
 			Subject:   id.String(), // user id
@@ -150,9 +154,11 @@ func (s Service) Parse(ctx context.Context, tokenString string) (user.User, erro
 	}
 
 	return user.User{
-		ID:       userID,
-		Username: pgtype.Text{String: tokenClaims.Username, Valid: true},
-		Role:     tokenClaims.Role,
+		ID:        userID,
+		Username:  pgtype.Text{String: tokenClaims.Username, Valid: true},
+		Name:      pgtype.Text{String: tokenClaims.Name, Valid: true},
+		AvatarUrl: pgtype.Text{String: tokenClaims.AvatarUrl, Valid: true},
+		Role:      tokenClaims.Role,
 	}, nil
 }
 


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Add Name and AvatarUrl to jwt claim to fit the structure of GetMe
