### PR TITLE
Fix: update request body field for internal API token login

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -370,14 +370,14 @@ func (h *Handler) InternalAPITokenLogin(w http.ResponseWriter, r *http.Request) 
 
 	// Parse and validate the request body
 	var req struct {
-		Username string `json:"username" validate:"required"`
+		UserIDStr string `json:"uid" validate:"required"`
 	}
 	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req); err != nil {
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
 		return
 	}
 
-	uid, err := uuid.Parse(req.Username)
+	uid, err := uuid.Parse(req.UserIDStr)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidAuthHeaderFormat, logger)
 		return


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Update request body field from Username to UserIDStr for internal API token login to clarify the data type
