### PR TITLE
Add CORS middleware and configure allowed origins

### DIFF
--- a/.deploy/dev/compose.yaml
+++ b/.deploy/dev/compose.yaml
@@ -18,7 +18,7 @@ services:
       OTEL_COLLECTOR_URL: 10.140.0.3:4317
       GOOGLE_OAUTH_CLIENT_ID: ${GOOGLE_OAUTH_CLIENT_ID}
       GOOGLE_OAUTH_CLIENT_SECRET: ${GOOGLE_OAUTH_CLIENT_SECRET}
-      ALLOW_ORIGINS: *
+      ALLOW_ORIGINS: "*"
     labels:
       - "vector.enable=true"
       - "traefik.enable=true"

--- a/.deploy/dev/compose.yaml
+++ b/.deploy/dev/compose.yaml
@@ -18,6 +18,7 @@ services:
       OTEL_COLLECTOR_URL: 10.140.0.3:4317
       GOOGLE_OAUTH_CLIENT_ID: ${GOOGLE_OAUTH_CLIENT_ID}
       GOOGLE_OAUTH_CLIENT_SECRET: ${GOOGLE_OAUTH_CLIENT_SECRET}
+      ALLOW_ORIGINS: *
     labels:
       - "vector.enable=true"
       - "traefik.enable=true"

--- a/.deploy/snapshot/compose.yaml
+++ b/.deploy/snapshot/compose.yaml
@@ -21,6 +21,7 @@ services:
       GOOGLE_OAUTH_CLIENT_ID: ${GOOGLE_OAUTH_CLIENT_ID}
       GOOGLE_OAUTH_CLIENT_SECRET: ${GOOGLE_OAUTH_CLIENT_SECRET}
       VERSION: $VERSION
+      ALLOW_ORIGINS: *
     labels:
       - "vector.enable=true"
       - "traefik.enable=true"

--- a/.deploy/snapshot/compose.yaml
+++ b/.deploy/snapshot/compose.yaml
@@ -21,7 +21,7 @@ services:
       GOOGLE_OAUTH_CLIENT_ID: ${GOOGLE_OAUTH_CLIENT_ID}
       GOOGLE_OAUTH_CLIENT_SECRET: ${GOOGLE_OAUTH_CLIENT_SECRET}
       VERSION: $VERSION
-      ALLOW_ORIGINS: *
+      ALLOW_ORIGINS: "*"
     labels:
       - "vector.enable=true"
       - "traefik.enable=true"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,13 +5,15 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	configutil "github.com/NYCU-SDC/summer/pkg/config"
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
-	"os"
-	"time"
 )
 
 const DefaultSecret = "default-secret"
@@ -31,6 +33,7 @@ type Config struct {
 	AccessTokenExpirationStr  string                  `yaml:"access_token_expiration" envconfig:"ACCESS_TOKEN_EXPIRATION"`
 	RefreshTokenExpirationStr string                  `yaml:"refresh_token_expiration" envconfig:"REFRESH_TOKEN_EXPIRATION"`
 	OtelCollectorUrl          string                  `yaml:"otel_collector_url" envconfig:"OTEL_COLLECTOR_URL"`
+	AllowOrigins              []string                `yaml:"allow_origins"      envconfig:"ALLOW_ORIGINS"`
 	GoogleOauth               googleOauth.GoogleOauth `yaml:"google_oauth"`
 
 	AccessTokenExpiration  time.Duration `yaml:"-"`
@@ -176,6 +179,12 @@ func FromEnv(config *Config, logger *LogBuffer) (*Config, error) {
 		} else {
 			return nil, err
 		}
+	}
+
+	// Allow origins
+	allowOrigins := os.Getenv("ALLOW_ORIGINS")
+	if allowOrigins != "" {
+		config.AllowOrigins = strings.Split(allowOrigins, ",")
 	}
 
 	envConfig := &Config{

--- a/internal/cors/middleware.go
+++ b/internal/cors/middleware.go
@@ -1,0 +1,25 @@
+package cors
+
+import (
+	"net/http"
+
+	corsutil "github.com/NYCU-SDC/summer/pkg/cors"
+	"go.uber.org/zap"
+)
+
+type Middleware struct {
+	logger       *zap.Logger
+	allowOrigins []string
+}
+
+func NewMiddleware(logger *zap.Logger, allowOrigins []string) Middleware {
+	logger.Info("CORS middleware initialized", zap.Strings("allow_origins", allowOrigins))
+	return Middleware{
+		logger:       logger,
+		allowOrigins: allowOrigins,
+	}
+}
+
+func (m Middleware) HandlerFunc(next http.HandlerFunc) http.HandlerFunc {
+	return corsutil.CORSMiddleware(next, m.logger, m.allowOrigins)
+}


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add CORS middleware to backend
- Load allowed origins from config / environment variable (`ALLOW_ORIGINS`)

## Additional Information
- Introduced new `cors` package with `NewMiddleware`
- Updated `main.go` to wrap entrypoint with CORS middleware
- Added `AllowOrigins` field to `Config` struct
- Support comma-separated origins via `ALLOW_ORIGINS` environment variable