### PR TITLE
Improve error handling in SubmitHandler 

### DIFF
--- a/internal/form/submit/handler.go
+++ b/internal/form/submit/handler.go
@@ -6,7 +6,9 @@ import (
 	"NYCU-SDC/core-system-backend/internal/form/shared"
 	"NYCU-SDC/core-system-backend/internal/user"
 	"context"
+	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	handlerutil "github.com/NYCU-SDC/summer/pkg/handler"
@@ -97,7 +99,13 @@ func (h *Handler) SubmitHandler(w http.ResponseWriter, r *http.Request) {
 
 	newResponse, errs := h.operator.Submit(traceCtx, formID, currentUser.ID, answerParams)
 	if errs != nil {
-		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		// Convert errors to strings and join them for better error handling
+		errorStrings := make([]string, len(errs))
+		for i, err := range errs {
+			errorStrings[i] = err.Error()
+		}
+		combinedErr := errors.New("form submission failed: [" + strings.Join(errorStrings, "; ") + "]")
+		h.problemWriter.WriteError(traceCtx, w, combinedErr, logger)
 		return
 	}
 


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Fix the error handling issue

## Additional Information
The issue is when validation errors occur, the service returns a slice of errors, but the handler is trying to pass an undefined variable `err` instead of properly handling the slice. This leads to the handler does not pass the error correctly and would return OK.

This PR wraps the error messages together to become an single error and creates a proper error object to pass to the problem writer.