### PR TITLE
[CORE-107] move UpdateOrg business logic to service layer

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -39,6 +39,7 @@ var (
 	// Unit Errors
 	ErrOrgSlugNotFound      = errors.New("org slug not found")
 	ErrOrgSlugAlreadyExists = errors.New("org slug already exists")
+	ErrOrgSlugInvalid       = errors.New("org slug is invalid")
 	ErrUnitNotFound         = errors.New("unit not found")
 	ErrSlugNotBelongToUnit  = errors.New("slug not belong to unit")
 
@@ -115,6 +116,8 @@ func ErrorHandler(err error) problem.Problem {
 		return problem.NewNotFoundProblem("org slug not found")
 	case errors.Is(err, ErrOrgSlugAlreadyExists):
 		return problem.NewValidateProblem("org slug already exists")
+	case errors.Is(err, ErrOrgSlugInvalid):
+		return problem.NewValidateProblem("org slug is invalid")
 	case errors.Is(err, ErrUnitNotFound):
 		return problem.NewNotFoundProblem("unit not found")
 	case errors.Is(err, ErrSlugNotBelongToUnit):

--- a/internal/unit/handler.go
+++ b/internal/unit/handler.go
@@ -27,7 +27,8 @@ type Store interface {
 	CreateUnit(ctx context.Context, name string, description string, slug string, metadata []byte) (Unit, error)
 	GetByID(ctx context.Context, id uuid.UUID, unitType Type) (Unit, error)
 	GetAllOrganizations(ctx context.Context) ([]Organization, error)
-	Update(ctx context.Context, id uuid.UUID, name string, description string, metadata []byte) (Unit, error)
+	UpdateOrg(ctx context.Context, originalSlug string, slug string, name string, description string, dbStrategy string, metadata []byte) (Unit, error)
+	UpdateUnit(ctx context.Context, id uuid.UUID, name string, description string, metadata []byte) (Unit, error)
 	Delete(ctx context.Context, id uuid.UUID, unitType Type) error
 	AddParent(ctx context.Context, id uuid.UUID, parentID uuid.UUID) (Unit, error)
 	ListSubUnits(ctx context.Context, id uuid.UUID, unitType Type) ([]Unit, error)
@@ -356,7 +357,7 @@ func (h *Handler) UpdateUnit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updatedUnit, err := h.store.Update(traceCtx, id, req.Name, req.Description, metadataBytes)
+	updatedUnit, err := h.store.UpdateUnit(traceCtx, id, req.Name, req.Description, metadataBytes)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to update unit: %w", err), logger)
 		return
@@ -382,52 +383,16 @@ func (h *Handler) UpdateOrg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, orgID, err := h.tenantStore.GetSlugStatus(traceCtx, slug)
-	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org ID by slug: %w", err), logger)
-		return
-	}
-
-	if req.Slug != slug {
-		matched, err := regexp.MatchString(slugPattern, req.Slug)
-		if err != nil || !matched {
-			h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("invalid slug format: must contain only alphanumeric characters, dashes, and underscores"), logger)
-			return
-		}
-
-		exists, err := h.tenantStore.SlugExists(traceCtx, req.Slug)
-		if err != nil {
-			h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to validate slug uniqueness: %w", err), logger)
-			return
-		}
-		if exists {
-			h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("slug already in use"), logger)
-			return
-		}
-	}
-	// TODO: Slug Validator
-
 	metadataBytes, err := json.Marshal(req.Metadata)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to marshal metadata: %w", err), logger)
 		return
 	}
 
-	var dbStrategy tenant.DbStrategy
+	// TODO: Slug Validator
 
-	if req.DbStrategy == "" || req.DbStrategy == string(DbStrategyShared) {
-		dbStrategy = "shared"
-	} else if req.DbStrategy == string(DbStrategyIsolated) {
-		dbStrategy = "isolated"
-	}
+	updatedOrg, err := h.store.UpdateOrg(traceCtx, slug, req.Slug, req.Name, req.Description, req.DbStrategy, metadataBytes)
 
-	_, err = h.tenantStore.Update(traceCtx, orgID, req.Slug, dbStrategy)
-	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to update organization tenant: %w", err), logger)
-		return
-	}
-
-	updatedOrg, err := h.store.Update(traceCtx, orgID, req.Name, req.Description, metadataBytes)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to update organization: %w", err), logger)
 		return

--- a/internal/unit/service.go
+++ b/internal/unit/service.go
@@ -2,6 +2,7 @@ package unit
 
 import (
 	"NYCU-SDC/core-system-backend/internal"
+	"NYCU-SDC/core-system-backend/internal/tenant"
 	"context"
 	"fmt"
 	databaseutil "github.com/NYCU-SDC/summer/pkg/database"
@@ -11,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"regexp"
 )
 
 type Querier interface {
@@ -272,8 +274,75 @@ func (s *Service) ListSubUnitIDs(ctx context.Context, id uuid.UUID, unitType Typ
 	return subUnitIDs, nil
 }
 
-// Update updates the base fields of a unit
-func (s *Service) Update(ctx context.Context, id uuid.UUID, name string, description string, metadata []byte) (Unit, error) {
+// UpdateOrg updates the fields of an organization
+func (s *Service) UpdateOrg(ctx context.Context, originalSlug string, slug string, name string, description string, dbStrategy string, metadata []byte) (Unit, error) {
+	traceCtx, span := s.tracer.Start(ctx, "UpdateUnit")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, s.logger)
+
+	_, orgID, err := s.tenantStore.GetSlugStatus(traceCtx, originalSlug)
+	if err != nil {
+		span.RecordError(err)
+		return Unit{}, err
+	}
+
+	if slug != originalSlug {
+		matched, err := regexp.MatchString(slugPattern, slug)
+		if err != nil || !matched {
+			span.RecordError(err)
+			return Unit{}, internal.ErrOrgSlugInvalid
+		}
+
+		exists, err := s.tenantStore.SlugExists(traceCtx, slug)
+		if err != nil {
+			span.RecordError(err)
+			return Unit{}, err
+		}
+
+		if exists {
+			span.RecordError(internal.ErrOrgSlugAlreadyExists)
+			return Unit{}, internal.ErrOrgSlugAlreadyExists
+		}
+	}
+
+	var tenantDbStrategy tenant.DbStrategy
+
+	if dbStrategy == "" || dbStrategy == string(DbStrategyShared) {
+		tenantDbStrategy = "shared"
+	} else if dbStrategy == string(DbStrategyIsolated) {
+		tenantDbStrategy = "isolated"
+	}
+
+	_, err = s.tenantStore.Update(traceCtx, orgID, slug, tenantDbStrategy)
+	if err != nil {
+		span.RecordError(err)
+		return Unit{}, err
+	}
+
+	unit, err := s.queries.Update(traceCtx, UpdateParams{
+		ID:          orgID,
+		Name:        pgtype.Text{String: name, Valid: name != ""},
+		Description: pgtype.Text{String: description, Valid: true},
+		Metadata:    metadata,
+	})
+	if err != nil {
+		err = databaseutil.WrapDBError(err, logger, "update unit")
+		span.RecordError(err)
+		return Unit{}, err
+	}
+
+	logger.Info("Updated unit",
+		zap.String("unitID", unit.ID.String()),
+		zap.String("unitName", unit.Name.String),
+		zap.String("unitDescription", unit.Description.String),
+		zap.ByteString("unitMetadata", unit.Metadata),
+	)
+
+	return unit, nil
+}
+
+// UpdateUnit updates the fields of a unit
+func (s *Service) UpdateUnit(ctx context.Context, id uuid.UUID, name string, description string, metadata []byte) (Unit, error) {
 	traceCtx, span := s.tracer.Start(ctx, "UpdateUnit")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)


### PR DESCRIPTION
## Type of changes
- Refactor

## Purpose
- Move `UpdateOrg` business logic to service layer


## Additional Information

Currently, the handler `unit.UpdateOrg` update two database schemas with separate calls when an update of organization is requested: 
1. h.tenantStore.Update()
2. h.store.Update()

The handler is refactored to make only one call to a single method in the service layer, and the update logic in service layer is refined accordingly in this PR.
