### PR TITLE
Add email validation and proper error handling for add member endpoints

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -45,6 +45,8 @@ var (
 	ErrOrgSlugInvalid       = errors.New("org slug is invalid")
 	ErrUnitNotFound         = errors.New("unit not found")
 	ErrSlugNotBelongToUnit  = errors.New("slug not belong to unit")
+	ErrInvalidEmailFormat   = errors.New("invalid email format")
+	ErrMemberEmailNotFound  = errors.New("member email not found")
 
 	// Inbox Errors
 	ErrInvalidIsReadParameter     = errors.New("invalid isRead parameter")
@@ -137,6 +139,10 @@ func ErrorHandler(err error) problem.Problem {
 		return problem.NewNotFoundProblem("unit not found")
 	case errors.Is(err, ErrSlugNotBelongToUnit):
 		return problem.NewNotFoundProblem("slug not belong to unit")
+	case errors.Is(err, ErrInvalidEmailFormat):
+		return problem.NewValidateProblem("invalid email format")
+	case errors.Is(err, ErrMemberEmailNotFound):
+		return problem.NewBadRequestProblem("member email not found")
 
 	// Form Errors
 	case errors.Is(err, ErrFormNotFound):

--- a/internal/unit/handler.go
+++ b/internal/unit/handler.go
@@ -632,17 +632,17 @@ func (h *Handler) AddOrgMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get Username from request body
+	// Get email from request body
 	var params struct {
-		Email string `json:"email"`
+		Email string `json:"email" validate:"required,email"`
 	}
 	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &params); err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("invalid request body: %w", err), logger)
 		return
 	}
 
-	if orgID == uuid.Nil || params.Email == "" {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("org ID or member username cannot be empty"), logger)
+	if orgID == uuid.Nil {
+		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("org ID cannot be empty"), logger)
 		return
 	}
 
@@ -672,15 +672,10 @@ func (h *Handler) AddUnitMember(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var params struct {
-		Email string `json:"email"`
+		Email string `json:"email" validate:"required,email"`
 	}
 	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &params); err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("invalid request body: %w", err), logger)
-		return
-	}
-
-	if params.Email == "" {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("member username cannot be empty"), logger)
 		return
 	}
 


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Fix issue where adding unit members with invalid or non-existent email returns 500 error
- Add email format validation using validator
- Return proper 400 Bad Request for client errors instead of 500
