### PR TITLE
Fix Workflow Node Type Field Format To Match API Spec

### DIFF
--- a/internal/form/workflow/handler.go
+++ b/internal/form/workflow/handler.go
@@ -39,6 +39,22 @@ type Handler struct {
 	store Store
 }
 
+// nodeTypeToUppercase converts database node type format (lowercase) to API format (uppercase).
+func nodeTypeToUppercase(nt NodeType) string {
+	switch nt {
+	case NodeTypeSection:
+		return "SECTION"
+	case NodeTypeCondition:
+		return "CONDITION"
+	case NodeTypeStart:
+		return "START"
+	case NodeTypeEnd:
+		return "END"
+	default:
+		return string(nt)
+	}
+}
+
 func NewHandler(
 	logger *zap.Logger,
 	validator *validator.Validate,
@@ -196,7 +212,7 @@ func (h *Handler) CreateNode(w http.ResponseWriter, r *http.Request) {
 
 	handlerutil.WriteJSONResponse(w, http.StatusCreated, createNodeResponse{
 		ID:    created.NodeID.String(),
-		Type:  string(created.NodeType),
+		Type:  nodeTypeToUppercase(created.NodeType),
 		Label: created.NodeLabel,
 	})
 }

--- a/internal/form/workflow/node_type_test.go
+++ b/internal/form/workflow/node_type_test.go
@@ -1,0 +1,43 @@
+package workflow
+
+import (
+	"testing"
+)
+
+func TestNodeTypeToUppercase(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    NodeType
+		expected string
+	}{
+		{
+			name:     "section to SECTION",
+			input:    NodeTypeSection,
+			expected: "SECTION",
+		},
+		{
+			name:     "condition to CONDITION",
+			input:    NodeTypeCondition,
+			expected: "CONDITION",
+		},
+		{
+			name:     "start to START",
+			input:    NodeTypeStart,
+			expected: "START",
+		},
+		{
+			name:     "end to END",
+			input:    NodeTypeEnd,
+			expected: "END",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := nodeTypeToUppercase(tt.input)
+			if result != tt.expected {
+				t.Errorf("nodeTypeToUppercase(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Align workflow node type API format with original spec (uppercase SECTION/CONDITION/START/END)

## Additional Information

https://github.com/NYCU-SDC/core-system-api/blob/97a01132ecc94b43da1e8a249ad698e573530474/src/form/workflow/models.tsp#L3