### PR TITLE
Fix Workflow JSON Type Conversion For GetWorkflow And UpdateWorkflow Handlers

### DIFF
--- a/internal/form/workflow/node_type_test.go
+++ b/internal/form/workflow/node_type_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -37,6 +38,148 @@ func TestNodeTypeToUppercase(t *testing.T) {
 			result := nodeTypeToUppercase(tt.input)
 			if result != tt.expected {
 				t.Errorf("nodeTypeToUppercase(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNodeTypeToLowercase(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "SECTION to section",
+			input:    "SECTION",
+			expected: "section",
+		},
+		{
+			name:     "CONDITION to condition",
+			input:    "CONDITION",
+			expected: "condition",
+		},
+		{
+			name:     "START to start",
+			input:    "START",
+			expected: "start",
+		},
+		{
+			name:     "END to end",
+			input:    "END",
+			expected: "end",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := nodeTypeToLowercase(tt.input)
+			if result != tt.expected {
+				t.Errorf("nodeTypeToLowercase(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWorkflowToAPIFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "convert workflow types to uppercase",
+			input: `[
+				{"id":"1","type":"start","label":"Start"},
+				{"id":"2","type":"section","label":"Section 1"},
+				{"id":"3","type":"condition","label":"Condition"},
+				{"id":"4","type":"end","label":"End"}
+			]`,
+			expected: `[
+				{"id":"1","type":"START","label":"Start"},
+				{"id":"2","type":"SECTION","label":"Section 1"},
+				{"id":"3","type":"CONDITION","label":"Condition"},
+				{"id":"4","type":"END","label":"End"}
+			]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := workflowToAPIFormat([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("workflowToAPIFormat() error = %v", err)
+			}
+
+			// Unmarshal both to compare structure
+			var resultNodes, expectedNodes []map[string]interface{}
+			if err := json.Unmarshal(result, &resultNodes); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+			if err := json.Unmarshal([]byte(tt.expected), &expectedNodes); err != nil {
+				t.Fatalf("failed to unmarshal expected: %v", err)
+			}
+
+			if len(resultNodes) != len(expectedNodes) {
+				t.Fatalf("length mismatch: got %d, want %d", len(resultNodes), len(expectedNodes))
+			}
+
+			for i := range resultNodes {
+				if resultNodes[i]["type"] != expectedNodes[i]["type"] {
+					t.Errorf("node %d type mismatch: got %v, want %v", i, resultNodes[i]["type"], expectedNodes[i]["type"])
+				}
+			}
+		})
+	}
+}
+
+func TestWorkflowFromAPIFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "convert workflow types to lowercase",
+			input: `[
+				{"id":"1","type":"START","label":"Start"},
+				{"id":"2","type":"SECTION","label":"Section 1"},
+				{"id":"3","type":"CONDITION","label":"Condition"},
+				{"id":"4","type":"END","label":"End"}
+			]`,
+			expected: `[
+				{"id":"1","type":"start","label":"Start"},
+				{"id":"2","type":"section","label":"Section 1"},
+				{"id":"3","type":"condition","label":"Condition"},
+				{"id":"4","type":"end","label":"End"}
+			]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := workflowFromAPIFormat([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("workflowFromAPIFormat() error = %v", err)
+			}
+
+			// Unmarshal both to compare structure
+			var resultNodes, expectedNodes []map[string]interface{}
+			if err := json.Unmarshal(result, &resultNodes); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+			if err := json.Unmarshal([]byte(tt.expected), &expectedNodes); err != nil {
+				t.Fatalf("failed to unmarshal expected: %v", err)
+			}
+
+			if len(resultNodes) != len(expectedNodes) {
+				t.Fatalf("length mismatch: got %d, want %d", len(resultNodes), len(expectedNodes))
+			}
+
+			for i := range resultNodes {
+				if resultNodes[i]["type"] != expectedNodes[i]["type"] {
+					t.Errorf("node %d type mismatch: got %v, want %v", i, resultNodes[i]["type"], expectedNodes[i]["type"])
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Complete the workflow node type API format fix by adding JSON-level conversion for GetWorkflow and UpdateWorkflow handlers
- PR #98 only handled CreateNode response conversion, but GetWorkflow and UpdateWorkflow return entire workflow arrays that need type conversion

## Changes
- Added `workflowToAPIFormat()` to convert entire workflow JSON arrays (database format → API format)
- Added `workflowFromAPIFormat()` for bidirectional conversion (API format → database format)
- Updated GetWorkflow handler to convert response workflow JSON to API format (lowercase → uppercase)
- Updated UpdateWorkflow handler to:
  - Convert incoming API format to database format before storing
  - Convert response back to API format
- Added comprehensive tests for all conversion functions in `node_type_test.go`

## Related
- Follows the same pattern as PR #96 (form visibility) and PR #97 (form status)
- Completes the work started in PR #98 by handling workflow array conversions
- API spec reference: https://github.com/NYCU-SDC/core-system-api/blob/97a01132ecc94b43da1e8a249ad698e573530474/src/form/workflow/models.tsp#L3

## Testing
- Added unit tests for `workflowToAPIFormat()` and `workflowFromAPIFormat()`