### PR TITLE
Fix validation error when UpdateWorkflow API receives requests without `type` field

### DIFF
--- a/internal/form/workflow/merge_type_test.go
+++ b/internal/form/workflow/merge_type_test.go
@@ -1,0 +1,125 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestMergeTypeFromDB(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiWorkflow string
+		dbWorkflow  string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "successful merge - all nodes exist in database",
+			apiWorkflow: `[
+				{"id":"1","label":"Start Node","next":"2"},
+				{"id":"2","label":"Section 1","next":"3"},
+				{"id":"3","label":"End Node"}
+			]`,
+			dbWorkflow: `[
+				{"id":"1","type":"start","label":"Start Node"},
+				{"id":"2","type":"section","label":"Section 1"},
+				{"id":"3","type":"end","label":"End Node"}
+			]`,
+			expectError: false,
+		},
+		{
+			name: "error - node not found in database",
+			apiWorkflow: `[
+				{"id":"1","label":"Start Node"},
+				{"id":"999","label":"Unknown Node"}
+			]`,
+			dbWorkflow: `[
+				{"id":"1","type":"start","label":"Start Node"}
+			]`,
+			expectError: true,
+			errorMsg:    "node with id '999' not found in current workflow",
+		},
+		{
+			name: "successful merge - with condition node",
+			apiWorkflow: `[
+				{"id":"1","label":"Start","next":"2"},
+				{"id":"2","label":"Condition","conditionRule":{},"nextTrue":"3","nextFalse":"4"},
+				{"id":"3","label":"End True"},
+				{"id":"4","label":"End False"}
+			]`,
+			dbWorkflow: `[
+				{"id":"1","type":"start","label":"Start"},
+				{"id":"2","type":"condition","label":"Condition"},
+				{"id":"3","type":"end","label":"End True"},
+				{"id":"4","type":"end","label":"End False"}
+			]`,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := mergeTypeFromDB([]byte(tt.apiWorkflow), []byte(tt.dbWorkflow))
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if tt.errorMsg != "" && !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("error message mismatch: got %v, want substring %v", err.Error(), tt.errorMsg)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Parse result to verify type field was added
+			var resultNodes []map[string]interface{}
+			if err := json.Unmarshal(result, &resultNodes); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+
+			// Parse database workflow to get expected types
+			var dbNodes []map[string]interface{}
+			if err := json.Unmarshal([]byte(tt.dbWorkflow), &dbNodes); err != nil {
+				t.Fatalf("failed to unmarshal dbWorkflow: %v", err)
+			}
+
+			// Build expected type map
+			expectedTypes := make(map[string]string)
+			for _, dbNode := range dbNodes {
+				id := dbNode["id"].(string)
+				nodeType := dbNode["type"].(string)
+				expectedTypes[id] = nodeType
+			}
+
+			// Verify each result node has the correct type
+			for _, resultNode := range resultNodes {
+				id, ok := resultNode["id"].(string)
+				if !ok {
+					t.Errorf("node missing id field")
+					continue
+				}
+
+				gotType, ok := resultNode["type"].(string)
+				if !ok {
+					t.Errorf("node %s missing type field", id)
+					continue
+				}
+
+				expectedType, exists := expectedTypes[id]
+				if !exists {
+					t.Errorf("node %s not found in expected types", id)
+					continue
+				}
+
+				if gotType != expectedType {
+					t.Errorf("node %s type mismatch: got %v, want %v", id, gotType, expectedType)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Fix validation error when UpdateWorkflow API receives requests without `type` field
- API spec's NodeRequest model doesn't include `type` field, but backend validator requires it
- Resolve validation failures: "node at index X missing required field 'type'"

<!-- Provide a brief description of the changes made in this pull request. -->

## Additional Information

### Problem
The API spec defines `NodeRequest` without a `type` field (only contains `id`, `label`, `conditionRule`, `next`, `nextTrue`, `nextFalse`), but the backend workflow validator requires every node to have a `type` field, causing validation failures.

Spec
```typespec
	@doc("Workflow node request model with linked list connections")
	model NodeRequest {
		@doc("Unique identifier for the node.")
		id: uuid;

		@doc("The label for the node")
		@example("開始表單")
		label: string;

		@doc("The condition rule for the node, only for condition nodes")
		conditionRule?: ConditionRule;

		@doc("Next node id for sequential flow (for start and section nodes)")
		next?: uuid;

		@doc("Next node id when condition is true (for condition nodes)")
		nextTrue?: uuid;

		@doc("Next node id when condition is false (for condition nodes)")
		nextFalse?: uuid;
	}
```

Payload
```json
[
    {
        "id": "{{startNodeId}}",
        "label": "開始表單",
        "next": "{{sectionNodeId}}"
    },
    {
        "id": "{{sectionNodeId}}",
        "label": "{{sectionNodeLabel}}",
        "next": "{{endNodeId}}"
    },
    {
        "id": "{{endNodeId}}",
        "label": "確認/送出"
    }
]
```

Error Message
```
workflow validation failed: validation failed: node at index 0 missing required field 'type'
node at index 1 missing required field 'type'
node at index 2 missing required field 'type'
workflow must contain exactly one start node, found 0
workflow must contain exactly one end node, found 0
```