### PR TITLE
[CORE-289] Remove relation API and add new unit creation API

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -152,7 +152,7 @@ func main() {
 
 	tenantService := tenant.NewService(logger, dbPool)
 	unitService := unit.NewService(logger, dbPool, tenantService)
-	
+
 	//Resource handler wiring for generic file deletion
 	answerQueries := answer.New(dbPool)
 	answerFileHandler := answer.NewFileResourceHandler(logger, answerQueries)
@@ -292,7 +292,6 @@ func main() {
 	// ----------------------
 	mux.Handle("GET /api/orgs/{slug}/units", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleMember, slugResolver)).HandlerFunc(unitHandler.ListOrgSubUnits))
 	mux.Handle("GET /api/orgs/{slug}/unit-ids", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleMember, slugResolver)).HandlerFunc(unitHandler.ListOrgSubUnitIDs))
-	mux.Handle("POST /api/orgs/relations", authMiddleware.HandlerFunc(unitHandler.AddParentChild))
 
 	// Organization Membership
 	// ----------------------

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -307,7 +307,8 @@ func main() {
 	// Unit Management
 	// ----------------------
 	mux.Handle("GET /api/orgs/{slug}/units/{unitId}", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleMember, unitResolver)).HandlerFunc(unitHandler.GetUnitByID))
-	mux.Handle("POST /api/orgs/{slug}/units", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleAdmin, slugResolver)).HandlerFunc(unitHandler.CreateUnit))
+	mux.Handle("POST /api/orgs/{slug}/units", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleAdmin, slugResolver)).HandlerFunc(unitHandler.CreateOrgUnit))
+	mux.Handle("POST /api/units/{unitId}/units", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleAdmin, unitResolver)).HandlerFunc(unitHandler.CreateUnit))
 	mux.Handle("PUT /api/orgs/{slug}/units/{unitId}", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleAdmin, unitResolver)).HandlerFunc(unitHandler.UpdateUnit))
 	mux.Handle("DELETE /api/orgs/{slug}/units/{unitId}", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleAdmin, slugResolver)).HandlerFunc(unitHandler.DeleteUnit))
 

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -308,7 +308,7 @@ func main() {
 	// ----------------------
 	mux.Handle("GET /api/orgs/{slug}/units/{unitId}", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleMember, unitResolver)).HandlerFunc(unitHandler.GetUnitByID))
 	mux.Handle("POST /api/orgs/{slug}/units", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleAdmin, slugResolver)).HandlerFunc(unitHandler.CreateOrgUnit))
-	mux.Handle("POST /api/units/{unitId}/units", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleAdmin, unitResolver)).HandlerFunc(unitHandler.CreateUnit))
+	mux.Handle("POST /api/units/{unitId}/units", authMiddleware.Append(unitRole.Require(auth.RoleAdmin, unitResolver)).HandlerFunc(unitHandler.CreateUnit))
 	mux.Handle("PUT /api/orgs/{slug}/units/{unitId}", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleAdmin, unitResolver)).HandlerFunc(unitHandler.UpdateUnit))
 	mux.Handle("DELETE /api/orgs/{slug}/units/{unitId}", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleAdmin, slugResolver)).HandlerFunc(unitHandler.DeleteUnit))
 

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -46,7 +46,7 @@ var (
 	ErrInvalidSectionID = errors.New("invalid section id")
 	ErrMissingFormID    = errors.New("missing form id")
 	ErrInvalidFormID    = errors.New("invalid form id")
-	
+
 	// JWT Authentication Errors
 	ErrMissingAuthHeader       = errors.New("missing access token")
 	ErrInvalidAuthHeaderFormat = errors.New("invalid access token")

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -76,13 +76,13 @@ var (
 	ErrMemberEmailNotFound   = errors.New("member email not found")
 	ErrCannotRemoveLastAdmin = errors.New("cannot remove the last admin of the unit")
 
-	ErrMissingUnitID      = errors.New("missing unit id")
-	ErrInvalidUnitID      = errors.New("invalid unit id")
-	ErrMissingMemberID    = errors.New("missing member id")
-	ErrInvalidMemberID    = errors.New("invalid member id")
-	ErrInvalidRequestBody = errors.New("invalid request body")
-	ErrInvalidRole        = errors.New("invalid role")
-	ErrInvalidMetadata    = errors.New("failed to marshal metadata")
+	ErrMissingUnitID         = errors.New("missing unit id")
+	ErrInvalidUnitID         = errors.New("invalid unit id")
+	ErrMissingMemberID       = errors.New("missing member id")
+	ErrInvalidMemberID       = errors.New("invalid member id")
+	ErrInvalidRequestBody    = errors.New("invalid request body")
+	ErrInvalidRole           = errors.New("invalid role")
+	ErrFailToMarshalMetadata = errors.New("failed to marshal metadata")
 
 	// Inbox Errors
 	ErrInvalidIsReadParameter     = errors.New("invalid isRead parameter")
@@ -137,6 +137,9 @@ var (
 	ErrInvalidFileType    = errors.New("file type is not allowed")
 	ErrCoverImageTooLarge = errors.New("cover image exceeds maximum size")
 	ErrInvalidImageFormat = errors.New("image format is invalid")
+
+	// Internal Handler Errors
+	ErrFailedToGetSlugFromContext = errors.New("failed to get org slug from context")
 )
 
 func NewProblemWriter() *problem.HttpWriter {
@@ -233,8 +236,8 @@ func ErrorHandler(err error) problem.Problem {
 		return problem.NewBadRequestProblem("invalid request body")
 	case errors.Is(err, ErrInvalidRole):
 		return problem.NewValidateProblem("invalid role value")
-	case errors.Is(err, ErrInvalidMetadata):
-		return problem.NewValidateProblem("failed to marshal metadata")
+	case errors.Is(err, ErrFailToMarshalMetadata):
+		return problem.NewInternalServerProblem("failed to marshal metadata")
 
 	// Form Errors
 	case errors.Is(err, ErrFormNotFound):
@@ -331,6 +334,11 @@ func ErrorHandler(err error) problem.Problem {
 		return problem.NewBadRequestProblem("invalid offset parameter")
 	case errors.Is(err, ErrInvalidFileType):
 		return problem.NewValidateProblem("file type is not allowed")
+
+	// Internal Handler Errors
+	case errors.Is(err, ErrFailedToGetSlugFromContext):
+		return problem.NewInternalServerProblem("failed to get org slug from context")
 	}
+
 	return problem.Problem{}
 }

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -82,6 +82,7 @@ var (
 	ErrInvalidMemberID    = errors.New("invalid member id")
 	ErrInvalidRequestBody = errors.New("invalid request body")
 	ErrInvalidRole        = errors.New("invalid role")
+	ErrInvalidMetadata    = errors.New("failed to marshal metadata")
 
 	// Inbox Errors
 	ErrInvalidIsReadParameter     = errors.New("invalid isRead parameter")
@@ -232,6 +233,8 @@ func ErrorHandler(err error) problem.Problem {
 		return problem.NewBadRequestProblem("invalid request body")
 	case errors.Is(err, ErrInvalidRole):
 		return problem.NewValidateProblem("invalid role value")
+	case errors.Is(err, ErrInvalidMetadata):
+		return problem.NewValidateProblem("failed to marshal metadata")
 
 	// Form Errors
 	case errors.Is(err, ErrFormNotFound):

--- a/internal/unit/handler.go
+++ b/internal/unit/handler.go
@@ -201,18 +201,6 @@ func convertOrgResponse(u Unit, slug string) OrganizationResponse {
 	}
 }
 
-type parentChildResponse struct {
-	ParentID *uuid.UUID `json:"parentId,omitempty"`
-	ChildID  uuid.UUID  `json:"childId"`
-	OrgID    uuid.UUID  `json:"orgId"`
-}
-
-type ParentChildRequest struct {
-	ParentID uuid.UUID `json:"parentId"`
-	ChildID  uuid.UUID `json:"childId" validate:"required"`
-	OrgID    uuid.UUID `json:"orgId" validate:"required"`
-}
-
 var slugPattern = `^[a-zA-Z0-9_-]+$`
 
 func (h *Handler) CreateUnit(w http.ResponseWriter, r *http.Request) {
@@ -492,36 +480,6 @@ func (h *Handler) DeleteUnit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handlerutil.WriteJSONResponse(w, http.StatusNoContent, nil)
-}
-
-func (h *Handler) AddParentChild(w http.ResponseWriter, r *http.Request) {
-	traceCtx, span := h.tracer.Start(r.Context(), "AddParent")
-	defer span.End()
-	logger := logutil.WithContext(traceCtx, h.logger)
-
-	var req ParentChildRequest
-	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req); err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("invalid request body: %w", err), logger)
-		return
-	}
-
-	pc, err := h.store.AddParent(traceCtx, req.ParentID, req.ChildID)
-	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to add parent-child relationship: %w", err), logger)
-		return
-	}
-
-	var parent *uuid.UUID
-	if req.ParentID != uuid.Nil {
-		pid := req.ParentID
-		parent = &pid
-	}
-	response := parentChildResponse{
-		ParentID: parent,
-		ChildID:  pc.ID,
-		OrgID:    pc.OrgID.Bytes,
-	}
-	handlerutil.WriteJSONResponse(w, http.StatusCreated, response)
 }
 
 func (h *Handler) ListOrgSubUnits(w http.ResponseWriter, r *http.Request) {

--- a/internal/unit/handler.go
+++ b/internal/unit/handler.go
@@ -25,7 +25,7 @@ import (
 type Store interface {
 	CreateOrganizationWithCurrentUserID(ctx context.Context, name string, description string, slug string, currentUserID uuid.UUID, metadata []byte) (Unit, error)
 	CreateOrganization(ctx context.Context, name string, description string, slug string) (Unit, error)
-	CreateUnit(ctx context.Context, name string, description string, slug string, metadata []byte) (Unit, error)
+	CreateUnit(ctx context.Context, name string, description string, parentID uuid.UUID, metadata []byte) (Unit, error)
 	GetByID(ctx context.Context, id uuid.UUID, unitType Type) (Unit, error)
 	GetAllOrganizations(ctx context.Context) ([]Organization, error)
 	ListOrganizationsOfUser(ctx context.Context, userID uuid.UUID) ([]Organization, error)
@@ -203,15 +203,15 @@ func convertOrgResponse(u Unit, slug string) OrganizationResponse {
 
 var slugPattern = `^[a-zA-Z0-9_-]+$`
 
-func (h *Handler) CreateUnit(w http.ResponseWriter, r *http.Request) {
-	traceCtx, span := h.tracer.Start(r.Context(), "CreateUnit")
+func (h *Handler) CreateOrgUnit(w http.ResponseWriter, r *http.Request) {
+	traceCtx, span := h.tracer.Start(r.Context(), "CreateOrgUnit")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, h.logger)
 
 	var req Request
 
 	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req); err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("invalid request body: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidRequestBody, logger)
 		return
 	}
 
@@ -227,7 +227,47 @@ func (h *Handler) CreateUnit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdUnit, err := h.store.CreateUnit(traceCtx, req.Name, req.Description, orgSlug, metadataBytes)
+	_, orgID, err := h.tenantStore.GetSlugStatus(traceCtx, orgSlug)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org ID by slug: %w", err), logger)
+		return
+	}
+
+	createdUnit, err := h.store.CreateUnit(traceCtx, req.Name, req.Description, orgID, metadataBytes)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to create unit: %w", err), logger)
+		return
+	}
+
+	handlerutil.WriteJSONResponse(w, http.StatusCreated, convertUnitResponse(createdUnit))
+}
+
+func (h *Handler) CreateUnit(w http.ResponseWriter, r *http.Request) {
+	traceCtx, span := h.tracer.Start(r.Context(), "CreateUnit")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, h.logger)
+
+	var req Request
+
+	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req); err != nil {
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidRequestBody, logger)
+		return
+	}
+
+	metadataBytes, err := json.Marshal(req.Metadata)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to marshal metadata: %w", err), logger)
+		return
+	}
+
+	idStr := r.PathValue("unitId")
+	unitID, err := handlerutil.ParseUUID(idStr)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidUnitID, logger)
+		return
+	}
+
+	createdUnit, err := h.store.CreateUnit(traceCtx, req.Name, req.Description, unitID, metadataBytes)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to create unit: %w", err), logger)
 		return

--- a/internal/unit/handler.go
+++ b/internal/unit/handler.go
@@ -170,7 +170,8 @@ func (h *Handler) createProfileResponseWithEmails(ctx context.Context, logger *z
 
 func convertUnitResponse(u Unit) UnitResponse {
 	var meta map[string]string
-	if err := json.Unmarshal(u.Metadata, &meta); err != nil {
+	err := json.Unmarshal(u.Metadata, &meta)
+	if err != nil {
 		meta = make(map[string]string)
 	}
 
@@ -186,7 +187,8 @@ func convertUnitResponse(u Unit) UnitResponse {
 
 func convertOrgResponse(u Unit, slug string) OrganizationResponse {
 	var meta map[string]string
-	if err := json.Unmarshal(u.Metadata, &meta); err != nil {
+	err := json.Unmarshal(u.Metadata, &meta)
+	if err != nil {
 		meta = make(map[string]string)
 	}
 
@@ -209,7 +211,6 @@ func (h *Handler) CreateOrgUnit(w http.ResponseWriter, r *http.Request) {
 	logger := logutil.WithContext(traceCtx, h.logger)
 
 	var req Request
-
 	err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidRequestBody, logger)
@@ -218,13 +219,13 @@ func (h *Handler) CreateOrgUnit(w http.ResponseWriter, r *http.Request) {
 
 	metadataBytes, err := json.Marshal(req.Metadata)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to marshal metadata: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailToMarshalMetadata, logger)
 		return
 	}
 
 	orgSlug, err := internal.GetSlugFromContext(traceCtx)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, internal.ErrOrgSlugNotFound, logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailedToGetSlugFromContext, logger)
 		return
 	}
 
@@ -255,7 +256,6 @@ func (h *Handler) CreateUnit(w http.ResponseWriter, r *http.Request) {
 	logger := logutil.WithContext(traceCtx, h.logger)
 
 	var req Request
-
 	err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidRequestBody, logger)
@@ -264,7 +264,7 @@ func (h *Handler) CreateUnit(w http.ResponseWriter, r *http.Request) {
 
 	metadataBytes, err := json.Marshal(req.Metadata)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidMetadata, logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailToMarshalMetadata, logger)
 		return
 	}
 
@@ -296,15 +296,15 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 	logger := logutil.WithContext(traceCtx, h.logger)
 
 	var req OrgRequest
-
-	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req); err != nil {
+	err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req)
+	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidRequestBody, logger)
 		return
 	}
 
 	metadataBytes, err := json.Marshal(req.Metadata)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidMetadata, logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailToMarshalMetadata, logger)
 		return
 	}
 
@@ -357,7 +357,7 @@ func (h *Handler) GetOrgByID(w http.ResponseWriter, r *http.Request) {
 
 	slug, err := internal.GetSlugFromContext(traceCtx)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org slug from context: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailedToGetSlugFromContext, logger)
 		return
 	}
 
@@ -441,7 +441,7 @@ func (h *Handler) UpdateUnit(w http.ResponseWriter, r *http.Request) {
 
 	metadataBytes, err := json.Marshal(req.Metadata)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to marshal metadata: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailToMarshalMetadata, logger)
 		return
 	}
 
@@ -460,20 +460,21 @@ func (h *Handler) UpdateOrg(w http.ResponseWriter, r *http.Request) {
 	logger := logutil.WithContext(traceCtx, h.logger)
 
 	var req OrgRequest
-	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req); err != nil {
+	err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req)
+	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("invalid request body: %w", err), logger)
 		return
 	}
 
 	slug, err := internal.GetSlugFromContext(traceCtx)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org slug from context: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailedToGetSlugFromContext, logger)
 		return
 	}
 
 	metadataBytes, err := json.Marshal(req.Metadata)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to marshal metadata: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailToMarshalMetadata, logger)
 		return
 	}
 
@@ -495,7 +496,7 @@ func (h *Handler) DeleteOrg(w http.ResponseWriter, r *http.Request) {
 
 	slug, err := internal.GetSlugFromContext(traceCtx)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org slug from context: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailedToGetSlugFromContext, logger)
 		return
 	}
 
@@ -543,7 +544,7 @@ func (h *Handler) ListOrgSubUnits(w http.ResponseWriter, r *http.Request) {
 
 	slug, err := internal.GetSlugFromContext(traceCtx)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org slug from context: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailedToGetSlugFromContext, logger)
 		return
 	}
 
@@ -599,7 +600,7 @@ func (h *Handler) ListOrgSubUnitIDs(w http.ResponseWriter, r *http.Request) {
 
 	slug, err := internal.GetSlugFromContext(traceCtx)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org slug from context: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailedToGetSlugFromContext, logger)
 		return
 	}
 
@@ -646,7 +647,7 @@ func (h *Handler) AddOrgMember(w http.ResponseWriter, r *http.Request) {
 
 	slug, err := internal.GetSlugFromContext(traceCtx)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org slug from context: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailedToGetSlugFromContext, logger)
 		return
 	}
 
@@ -660,7 +661,8 @@ func (h *Handler) AddOrgMember(w http.ResponseWriter, r *http.Request) {
 	var params struct {
 		Email string `json:"email" validate:"required,email"`
 	}
-	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &params); err != nil {
+	err = handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &params)
+	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("invalid request body: %w", err), logger)
 		return
 	}
@@ -698,7 +700,8 @@ func (h *Handler) AddUnitMember(w http.ResponseWriter, r *http.Request) {
 	var params struct {
 		Email string `json:"email" validate:"required,email"`
 	}
-	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &params); err != nil {
+	err = handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &params)
+	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("invalid request body: %w", err), logger)
 		return
 	}
@@ -722,7 +725,7 @@ func (h *Handler) ListOrgMembers(w http.ResponseWriter, r *http.Request) {
 
 	slug, err := internal.GetSlugFromContext(traceCtx)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org slug from context: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailedToGetSlugFromContext, logger)
 		return
 	}
 
@@ -780,7 +783,7 @@ func (h *Handler) RemoveOrgMember(w http.ResponseWriter, r *http.Request) {
 
 	slug, err := internal.GetSlugFromContext(traceCtx)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org slug from context: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrFailedToGetSlugFromContext, logger)
 		return
 	}
 

--- a/internal/unit/handler.go
+++ b/internal/unit/handler.go
@@ -23,7 +23,7 @@ import (
 )
 
 type Store interface {
-	CreateOrganizationWithCurrentUserID(ctx context.Context, name string, description string, slug string, currentUserID uuid.UUID, metadata []byte) (Unit, error)
+	CreateOrganizationWithUserID(ctx context.Context, name string, description string, slug string, currentUserID uuid.UUID, metadata []byte) (Unit, error)
 	CreateOrganization(ctx context.Context, name string, description string, slug string) (Unit, error)
 	CreateUnitWithUserID(ctx context.Context, name string, description string, parentID uuid.UUID, UserID uuid.UUID, metadata []byte) (Unit, error)
 	GetByID(ctx context.Context, id uuid.UUID, unitType Type) (Unit, error)
@@ -210,7 +210,8 @@ func (h *Handler) CreateOrgUnit(w http.ResponseWriter, r *http.Request) {
 
 	var req Request
 
-	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req); err != nil {
+	err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req)
+	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidRequestBody, logger)
 		return
 	}
@@ -223,23 +224,23 @@ func (h *Handler) CreateOrgUnit(w http.ResponseWriter, r *http.Request) {
 
 	orgSlug, err := internal.GetSlugFromContext(traceCtx)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org slug from context: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrOrgSlugNotFound, logger)
 		return
 	}
 
 	_, orgID, err := h.tenantStore.GetSlugStatus(traceCtx, orgSlug)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to get org ID by slug: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrOrgSlugNotFound, logger)
 		return
 	}
 
-	User, ok := user.GetFromContext(traceCtx)
+	currentUser, ok := user.GetFromContext(traceCtx)
 	if !ok {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("no user found in request context"), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrNoUserInContext, logger)
 		return
 	}
 
-	createdUnit, err := h.store.CreateUnitWithUserID(traceCtx, req.Name, req.Description, orgID, User.ID, metadataBytes)
+	createdUnit, err := h.store.CreateUnitWithUserID(traceCtx, req.Name, req.Description, orgID, currentUser.ID, metadataBytes)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to create unit: %w", err), logger)
 		return
@@ -255,14 +256,15 @@ func (h *Handler) CreateUnit(w http.ResponseWriter, r *http.Request) {
 
 	var req Request
 
-	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req); err != nil {
+	err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req)
+	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidRequestBody, logger)
 		return
 	}
 
 	metadataBytes, err := json.Marshal(req.Metadata)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to marshal metadata: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidMetadata, logger)
 		return
 	}
 
@@ -273,13 +275,13 @@ func (h *Handler) CreateUnit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	User, ok := user.GetFromContext(traceCtx)
+	currentUser, ok := user.GetFromContext(traceCtx)
 	if !ok {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("no user found in request context"), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrNoUserInContext, logger)
 		return
 	}
 
-	createdUnit, err := h.store.CreateUnitWithUserID(traceCtx, req.Name, req.Description, unitID, User.ID, metadataBytes)
+	createdUnit, err := h.store.CreateUnitWithUserID(traceCtx, req.Name, req.Description, unitID, currentUser.ID, metadataBytes)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to create unit: %w", err), logger)
 		return
@@ -296,19 +298,19 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 	var req OrgRequest
 
 	if err := handlerutil.ParseAndValidateRequestBody(traceCtx, h.validator, r, &req); err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("invalid request body: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidRequestBody, logger)
 		return
 	}
 
 	metadataBytes, err := json.Marshal(req.Metadata)
 	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to marshal metadata: %w", err), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidMetadata, logger)
 		return
 	}
 
 	currentUser, ok := user.GetFromContext(traceCtx)
 	if !ok {
-		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("no user found in request context"), logger)
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrNoUserInContext, logger)
 		return
 	}
 
@@ -318,7 +320,7 @@ func (h *Handler) CreateOrg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdOrg, err := h.store.CreateOrganizationWithCurrentUserID(traceCtx, req.Name, req.Description, req.Slug, currentUser.ID, metadataBytes)
+	createdOrg, err := h.store.CreateOrganizationWithUserID(traceCtx, req.Name, req.Description, req.Slug, currentUser.ID, metadataBytes)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to create org: %w", err), logger)
 		return

--- a/internal/unit/handler.go
+++ b/internal/unit/handler.go
@@ -25,7 +25,7 @@ import (
 type Store interface {
 	CreateOrganizationWithCurrentUserID(ctx context.Context, name string, description string, slug string, currentUserID uuid.UUID, metadata []byte) (Unit, error)
 	CreateOrganization(ctx context.Context, name string, description string, slug string) (Unit, error)
-	CreateUnit(ctx context.Context, name string, description string, parentID uuid.UUID, metadata []byte) (Unit, error)
+	CreateUnitWithUserID(ctx context.Context, name string, description string, parentID uuid.UUID, UserID uuid.UUID, metadata []byte) (Unit, error)
 	GetByID(ctx context.Context, id uuid.UUID, unitType Type) (Unit, error)
 	GetAllOrganizations(ctx context.Context) ([]Organization, error)
 	ListOrganizationsOfUser(ctx context.Context, userID uuid.UUID) ([]Organization, error)
@@ -233,7 +233,13 @@ func (h *Handler) CreateOrgUnit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdUnit, err := h.store.CreateUnit(traceCtx, req.Name, req.Description, orgID, metadataBytes)
+	User, ok := user.GetFromContext(traceCtx)
+	if !ok {
+		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("no user found in request context"), logger)
+		return
+	}
+
+	createdUnit, err := h.store.CreateUnitWithUserID(traceCtx, req.Name, req.Description, orgID, User.ID, metadataBytes)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to create unit: %w", err), logger)
 		return
@@ -267,7 +273,13 @@ func (h *Handler) CreateUnit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	createdUnit, err := h.store.CreateUnit(traceCtx, req.Name, req.Description, unitID, metadataBytes)
+	User, ok := user.GetFromContext(traceCtx)
+	if !ok {
+		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("no user found in request context"), logger)
+		return
+	}
+
+	createdUnit, err := h.store.CreateUnitWithUserID(traceCtx, req.Name, req.Description, unitID, User.ID, metadataBytes)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, fmt.Errorf("failed to create unit: %w", err), logger)
 		return

--- a/internal/unit/service.go
+++ b/internal/unit/service.go
@@ -140,21 +140,27 @@ func (s *Service) CreateOrganizationWithCurrentUserID(ctx context.Context, name 
 }
 
 // CreateUnit creates a new unit or organization
-func (s *Service) CreateUnit(ctx context.Context, name string, description string, slug string, metadata []byte) (Unit, error) {
+func (s *Service) CreateUnit(ctx context.Context, name string, description string, parentID uuid.UUID, metadata []byte) (Unit, error) {
 	traceCtx, span := s.tracer.Start(ctx, "CreateUnit")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	_, orgID, err := s.tenantStore.GetSlugStatus(traceCtx, slug)
+	parent, err := s.queries.GetByID(ctx, parentID)
 	if err != nil {
-		span.RecordError(err)
 		return Unit{}, err
+	}
+
+	var orgID uuid.UUID
+	if parent.Type == UnitTypeOrganization {
+		orgID = parent.ID
+	} else {
+		orgID = parent.OrgID.Bytes
 	}
 
 	unit, err := s.queries.Create(traceCtx, CreateParams{
 		Name:        pgtype.Text{String: name, Valid: name != ""},
 		OrgID:       pgtype.UUID{Bytes: orgID, Valid: true},
-		ParentID:    pgtype.UUID{Bytes: orgID, Valid: true},
+		ParentID:    pgtype.UUID{Bytes: parentID, Valid: true},
 		Description: pgtype.Text{String: description, Valid: true},
 		Metadata:    metadata,
 		Type:        UnitTypeUnit,
@@ -167,6 +173,7 @@ func (s *Service) CreateUnit(ctx context.Context, name string, description strin
 
 	logger.Info(fmt.Sprintf("Created %s", unit.Type),
 		zap.String("unit_id", unit.ID.String()),
+		zap.String("parent_id", parentID.String()),
 		zap.String("org_id", orgID.String()),
 		zap.String("name", unit.Name.String),
 		zap.String("description", unit.Description.String),

--- a/internal/unit/service.go
+++ b/internal/unit/service.go
@@ -95,8 +95,8 @@ func NewService(logger *zap.Logger, db DBTX, tenantStore tenantStore) *Service {
 	}
 }
 
-func (s *Service) CreateOrganizationWithCurrentUserID(ctx context.Context, name string, description string, slug string, currentUserID uuid.UUID, metadata []byte) (Unit, error) {
-	traceCtx, span := s.tracer.Start(ctx, "CreateOrganizationWithCurrentUserID")
+func (s *Service) CreateOrganizationWithUserID(ctx context.Context, name string, description string, slug string, userID uuid.UUID, metadata []byte) (Unit, error) {
+	traceCtx, span := s.tracer.Start(ctx, "CreateOrganizationWithUserID")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
@@ -124,7 +124,7 @@ func (s *Service) CreateOrganizationWithCurrentUserID(ctx context.Context, name 
 		return Unit{}, err
 	}
 
-	_, err = s.tenantStore.Create(traceCtx, org.ID, currentUserID, slug)
+	_, err = s.tenantStore.Create(traceCtx, org.ID, userID, slug)
 	if err != nil {
 		span.RecordError(err)
 		return Unit{}, err
@@ -132,7 +132,7 @@ func (s *Service) CreateOrganizationWithCurrentUserID(ctx context.Context, name 
 
 	_, err = s.queries.AddUnitMemberWithRole(traceCtx, AddUnitMemberWithRoleParams{
 		UnitID:   org.ID,
-		MemberID: currentUserID,
+		MemberID: userID,
 		Role:     UnitRoleAdmin,
 	})
 	if err != nil {
@@ -150,9 +150,8 @@ func (s *Service) CreateOrganizationWithCurrentUserID(ctx context.Context, name 
 	return org, nil
 }
 
-// CreateUnit creates a new unit or organization
-func (s *Service) CreateUnitWithUserID(ctx context.Context, name string, description string, parentID uuid.UUID, UserID uuid.UUID, metadata []byte) (Unit, error) {
-	traceCtx, span := s.tracer.Start(ctx, "CreateUnit")
+func (s *Service) CreateUnitWithUserID(ctx context.Context, name string, description string, parentID uuid.UUID, userID uuid.UUID, metadata []byte) (Unit, error) {
+	traceCtx, span := s.tracer.Start(ctx, "CreateUnitWithUserID")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
@@ -184,7 +183,7 @@ func (s *Service) CreateUnitWithUserID(ctx context.Context, name string, descrip
 
 	_, err = s.queries.AddUnitMemberWithRole(traceCtx, AddUnitMemberWithRoleParams{
 		UnitID:   unit.ID,
-		MemberID: UserID,
+		MemberID: userID,
 		Role:     UnitRoleAdmin,
 	})
 	if err != nil {
@@ -244,49 +243,6 @@ func (s *Service) CreateOrganization(ctx context.Context, name string, descripti
 		zap.String("metadata", string(org.Metadata)))
 
 	return org, nil
-}
-
-// CreateUnit creates a new unit or organization
-func (s *Service) CreateUnit(ctx context.Context, name string, description string, parentID uuid.UUID, metadata []byte) (Unit, error) {
-	traceCtx, span := s.tracer.Start(ctx, "CreateUnit")
-	defer span.End()
-	logger := logutil.WithContext(traceCtx, s.logger)
-
-	parent, err := s.queries.GetByID(ctx, parentID)
-	if err != nil {
-		return Unit{}, err
-	}
-
-	var orgID uuid.UUID
-	if parent.Type == UnitTypeOrganization {
-		orgID = parent.ID
-	} else {
-		orgID = parent.OrgID.Bytes
-	}
-
-	unit, err := s.queries.Create(traceCtx, CreateParams{
-		Name:        pgtype.Text{String: name, Valid: name != ""},
-		OrgID:       pgtype.UUID{Bytes: orgID, Valid: true},
-		ParentID:    pgtype.UUID{Bytes: parentID, Valid: true},
-		Description: pgtype.Text{String: description, Valid: true},
-		Metadata:    metadata,
-		Type:        UnitTypeUnit,
-	})
-	if err != nil {
-		err = databaseutil.WrapDBError(err, logger, "create unit")
-		span.RecordError(err)
-		return Unit{}, err
-	}
-
-	logger.Info(fmt.Sprintf("Created %s", unit.Type),
-		zap.String("unit_id", unit.ID.String()),
-		zap.String("parent_id", parentID.String()),
-		zap.String("org_id", orgID.String()),
-		zap.String("name", unit.Name.String),
-		zap.String("description", unit.Description.String),
-		zap.String("metadata", string(unit.Metadata)))
-
-	return unit, nil
 }
 
 func (s *Service) GetAllOrganizations(ctx context.Context) ([]Organization, error) {

--- a/internal/unit/service.go
+++ b/internal/unit/service.go
@@ -130,6 +130,17 @@ func (s *Service) CreateOrganizationWithCurrentUserID(ctx context.Context, name 
 		return Unit{}, err
 	}
 
+	_, err = s.queries.AddUnitMemberWithRole(traceCtx, AddUnitMemberWithRoleParams{
+		UnitID:   org.ID,
+		MemberID: currentUserID,
+		Role:     UnitRoleAdmin,
+	})
+	if err != nil {
+		err = databaseutil.WrapDBError(err, logger, "add org admin")
+		span.RecordError(err)
+		return Unit{}, err
+	}
+
 	logger.Info("Created organization",
 		zap.String("org_id", org.ID.String()),
 		zap.String("name", org.Name.String),
@@ -140,7 +151,7 @@ func (s *Service) CreateOrganizationWithCurrentUserID(ctx context.Context, name 
 }
 
 // CreateUnit creates a new unit or organization
-func (s *Service) CreateUnit(ctx context.Context, name string, description string, parentID uuid.UUID, metadata []byte) (Unit, error) {
+func (s *Service) CreateUnitWithUserID(ctx context.Context, name string, description string, parentID uuid.UUID, UserID uuid.UUID, metadata []byte) (Unit, error) {
 	traceCtx, span := s.tracer.Start(ctx, "CreateUnit")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -167,6 +178,17 @@ func (s *Service) CreateUnit(ctx context.Context, name string, description strin
 	})
 	if err != nil {
 		err = databaseutil.WrapDBError(err, logger, "create unit")
+		span.RecordError(err)
+		return Unit{}, err
+	}
+
+	_, err = s.queries.AddUnitMemberWithRole(traceCtx, AddUnitMemberWithRoleParams{
+		UnitID:   unit.ID,
+		MemberID: UserID,
+		Role:     UnitRoleAdmin,
+	})
+	if err != nil {
+		err = databaseutil.WrapDBError(err, logger, "add unit admin")
 		span.RecordError(err)
 		return Unit{}, err
 	}
@@ -222,6 +244,49 @@ func (s *Service) CreateOrganization(ctx context.Context, name string, descripti
 		zap.String("metadata", string(org.Metadata)))
 
 	return org, nil
+}
+
+// CreateUnit creates a new unit or organization
+func (s *Service) CreateUnit(ctx context.Context, name string, description string, parentID uuid.UUID, metadata []byte) (Unit, error) {
+	traceCtx, span := s.tracer.Start(ctx, "CreateUnit")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, s.logger)
+
+	parent, err := s.queries.GetByID(ctx, parentID)
+	if err != nil {
+		return Unit{}, err
+	}
+
+	var orgID uuid.UUID
+	if parent.Type == UnitTypeOrganization {
+		orgID = parent.ID
+	} else {
+		orgID = parent.OrgID.Bytes
+	}
+
+	unit, err := s.queries.Create(traceCtx, CreateParams{
+		Name:        pgtype.Text{String: name, Valid: name != ""},
+		OrgID:       pgtype.UUID{Bytes: orgID, Valid: true},
+		ParentID:    pgtype.UUID{Bytes: parentID, Valid: true},
+		Description: pgtype.Text{String: description, Valid: true},
+		Metadata:    metadata,
+		Type:        UnitTypeUnit,
+	})
+	if err != nil {
+		err = databaseutil.WrapDBError(err, logger, "create unit")
+		span.RecordError(err)
+		return Unit{}, err
+	}
+
+	logger.Info(fmt.Sprintf("Created %s", unit.Type),
+		zap.String("unit_id", unit.ID.String()),
+		zap.String("parent_id", parentID.String()),
+		zap.String("org_id", orgID.String()),
+		zap.String("name", unit.Name.String),
+		zap.String("description", unit.Description.String),
+		zap.String("metadata", string(unit.Metadata)))
+
+	return unit, nil
 }
 
 func (s *Service) GetAllOrganizations(ctx context.Context) ([]Organization, error) {

--- a/test/integration/unit/unit_test.go
+++ b/test/integration/unit/unit_test.go
@@ -147,10 +147,10 @@ func TestUnitService_Create(t *testing.T) {
 
 			var result unit.Unit
 			if params.unitType == unit.TypeOrg {
-				result, err = unitService.CreateOrganizationWithCurrentUserID(ctx, params.name, params.description, params.slug, params.ownerID, params.metadata)
+				result, err = unitService.CreateOrganizationWithUserID(ctx, params.name, params.description, params.slug, params.ownerID, params.metadata)
 				require.Equal(t, tc.expectedErr, err != nil, "expected error: %v, got: %v", tc.expectedErr, err)
 			} else {
-				result, err = unitService.CreateUnit(ctx, params.name, params.description, params.parentUnitID, params.metadata)
+				result, err = unitService.CreateUnitWithUserID(ctx, params.name, params.description, params.parentUnitID, params.ownerID, params.metadata)
 				require.Equal(t, tc.expectedErr, err != nil, "expected error: %v, got: %v", tc.expectedErr, err)
 			}
 

--- a/test/integration/unit/unit_test.go
+++ b/test/integration/unit/unit_test.go
@@ -150,7 +150,7 @@ func TestUnitService_Create(t *testing.T) {
 				result, err = unitService.CreateOrganizationWithCurrentUserID(ctx, params.name, params.description, params.slug, params.ownerID, params.metadata)
 				require.Equal(t, tc.expectedErr, err != nil, "expected error: %v, got: %v", tc.expectedErr, err)
 			} else {
-				result, err = unitService.CreateUnit(ctx, params.name, params.description, params.slug, params.metadata)
+				result, err = unitService.CreateUnit(ctx, params.name, params.description, params.parentUnitID, params.metadata)
 				require.Equal(t, tc.expectedErr, err != nil, "expected error: %v, got: %v", tc.expectedErr, err)
 			}
 


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Remove /api/orgs/relations API
- Add /api/units/{unitId}/units API
- Add create unit service, now there are two service to create unit, with userId or not, just like create org
- Fix an issue, create org with userId did not set default admin. Now create org/unit with userId will set default admin


## Additional Information
Consider to check the existence of unitId in the handler in the future, because there is no such check in all handler function. I think this will be another work.