### PR TITLE
[CORE-304] Fix Binding Account RedirectURL

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -265,8 +265,8 @@ func main() {
 	mux.Handle("GET /api/auth/logout", basicMiddleware.HandlerFunc(authHandler.Logout))
 	mux.Handle("POST /api/auth/logout", basicMiddleware.HandlerFunc(authHandler.Logout))
 
-	mux.Handle("POST /api/auth/link", basicMiddleware.HandlerFunc(authHandler.LinkAccount))
-	mux.Handle("POST /api/auth/link/abort", basicMiddleware.HandlerFunc(authHandler.LinkAccountAbort))
+	mux.Handle("POST /api/auth/link-account", basicMiddleware.HandlerFunc(authHandler.LinkAccount))
+	mux.Handle("POST /api/auth/link-account/abort", basicMiddleware.HandlerFunc(authHandler.LinkAccountAbort))
 
 	// JWT refresh
 	// ----------------------

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -37,7 +37,7 @@ type JWTIssuer interface {
 	Parse(ctx context.Context, tokenString string) (user.User, error)
 	ParseState(ctx context.Context, tokenString string) (*jwt.OauthProxyClaims, error)
 	ParseFormState(ctx context.Context, tokenString string) (callbackURL string, responseID uuid.UUID, questionID uuid.UUID, redirectURL string, err error)
-	ParseLinkToken(ctx context.Context, tokenString string) (*jwt.LinkClaims, error)
+	ParseLinkToken(ctx context.Context, tokenString string) (*jwt.LinkClaims, uuid.UUID, error)
 	GenerateRefreshToken(ctx context.Context, userID uuid.UUID) (jwt.RefreshToken, error)
 	GetUserIDByRefreshToken(ctx context.Context, refreshTokenID uuid.UUID) (uuid.UUID, error)
 }
@@ -535,13 +535,7 @@ func (h *Handler) LinkAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	linkClaims, err := h.jwtIssuer.ParseLinkToken(traceCtx, linkTokenStr)
-	if err != nil {
-		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidAuthHeaderFormat, logger)
-		return
-	}
-
-	userID, err := uuid.Parse(linkClaims.UserID)
+	linkClaims, userID, err := h.jwtIssuer.ParseLinkToken(traceCtx, linkTokenStr)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidAuthHeaderFormat, logger)
 		return
@@ -564,8 +558,8 @@ func (h *Handler) LinkAccount(w http.ResponseWriter, r *http.Request) {
 
 	h.setAccessAndRefreshCookies(w, baseURL.Host, accessTokenID, refreshTokenID)
 
-	var redirectURL string
-	if linkClaims.RedirectURL == "" {
+	redirectURL := linkClaims.RedirectURL
+	if redirectURL == "" {
 		if h.environment == "snapshot" || h.environment == "no-env" {
 			redirectURL = "/api/users/me"
 		} else {
@@ -601,7 +595,7 @@ func (h *Handler) LinkAccountAbort(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	linkClaims, err := h.jwtIssuer.ParseLinkToken(traceCtx, linkTokenStr)
+	linkClaims, _, err := h.jwtIssuer.ParseLinkToken(traceCtx, linkTokenStr)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidAuthHeaderFormat, logger)
 		return
@@ -609,8 +603,8 @@ func (h *Handler) LinkAccountAbort(w http.ResponseWriter, r *http.Request) {
 
 	h.clearLinkCookie(w, domain)
 
-	var redirectURL string
-	if linkClaims.RedirectURL == "" {
+	redirectURL := linkClaims.RedirectURL
+	if redirectURL == "" {
 		if h.environment == "snapshot" || h.environment == "no-env" {
 			redirectURL = "/api/users/me"
 		} else {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -33,11 +33,11 @@ type JWTIssuer interface {
 	New(ctx context.Context, user user.User) (string, error)
 	NewState(ctx context.Context, service, environment, callbackURL, redirectURL string) (string, error)
 	NewFormState(ctx context.Context, callbackURL string, responseID uuid.UUID, questionID uuid.UUID, redirectURL string) (string, error)
-	NewLinkToken(ctx context.Context, provider, providerID, existingProvider, existingProviderID, userID string) (string, error)
+	NewLinkToken(ctx context.Context, provider, providerID, existingProvider, existingProviderID, redirectURL, userID string) (string, error)
 	Parse(ctx context.Context, tokenString string) (user.User, error)
 	ParseState(ctx context.Context, tokenString string) (*jwt.OauthProxyClaims, error)
 	ParseFormState(ctx context.Context, tokenString string) (callbackURL string, responseID uuid.UUID, questionID uuid.UUID, redirectURL string, err error)
-	ParseLinkToken(ctx context.Context, tokenString string) (provider, providerID, existingProvider, existingProviderID string, userID uuid.UUID, err error)
+	ParseLinkToken(ctx context.Context, tokenString string) (provider, providerID, existingProvider, existingProviderID, redirectURL string, userID uuid.UUID, err error)
 	GenerateRefreshToken(ctx context.Context, userID uuid.UUID) (jwt.RefreshToken, error)
 	GetUserIDByRefreshToken(ctx context.Context, refreshTokenID uuid.UUID) (uuid.UUID, error)
 }
@@ -289,7 +289,7 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 	// Do not issue access tokens yet; set a linking cookie and
 	// redirect to the binding confirmation page.
 	if result.ExistingProvider != "" {
-		linkToken, err := h.jwtIssuer.NewLinkToken(traceCtx, auth.Provider, auth.ProviderID, result.ExistingProvider, result.ExistingProviderID, result.UserID.String())
+		linkToken, err := h.jwtIssuer.NewLinkToken(traceCtx, auth.Provider, auth.ProviderID, result.ExistingProvider, result.ExistingProviderID, redirectTo, result.UserID.String())
 		if err != nil {
 			h.problemWriter.WriteError(traceCtx, w, internal.ErrInternalServerError, logger)
 			return
@@ -535,7 +535,7 @@ func (h *Handler) LinkAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	provider, providerID, existingProvider, existingProviderID, userID, err := h.jwtIssuer.ParseLinkToken(traceCtx, linkTokenStr)
+	provider, providerID, existingProvider, existingProviderID, redirectURL, userID, err := h.jwtIssuer.ParseLinkToken(traceCtx, linkTokenStr)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidAuthHeaderFormat, logger)
 		return
@@ -558,7 +558,15 @@ func (h *Handler) LinkAccount(w http.ResponseWriter, r *http.Request) {
 
 	h.setAccessAndRefreshCookies(w, baseURL.Host, accessTokenID, refreshTokenID)
 
-	http.Redirect(w, r, "/", http.StatusFound)
+	if redirectURL == "" {
+		if h.environment == "snapshot" || h.environment == "no-env" {
+			redirectURL = "/api/users/me"
+		} else {
+			redirectURL = "/"
+		}
+	}
+
+	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 // LinkAccountAbort aborts the merge process and logout user
@@ -574,9 +582,35 @@ func (h *Handler) LinkAccountAbort(w http.ResponseWriter, r *http.Request) {
 	}
 	domain := baseURL.Host
 
+	linkTokenCookie, err := r.Cookie(LinkTokenCookieName)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrMissingAuthHeader, logger)
+		return
+	}
+
+	linkTokenStr := linkTokenCookie.Value
+	if linkTokenStr == "" {
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrMissingAuthHeader, logger)
+		return
+	}
+
+	_, _, _, _, redirectURL, _, err := h.jwtIssuer.ParseLinkToken(traceCtx, linkTokenStr)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidAuthHeaderFormat, logger)
+		return
+	}
+
 	h.clearLinkCookie(w, domain)
 
-	http.Redirect(w, r, "/", http.StatusFound)
+	if redirectURL == "" {
+		if h.environment == "snapshot" || h.environment == "no-env" {
+			redirectURL = "/api/users/me"
+		} else {
+			redirectURL = "/"
+		}
+	}
+
+	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 // setAccessAndRefreshCookies sets the access/refresh cookies with HTTP-only and secure flags

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -37,7 +37,7 @@ type JWTIssuer interface {
 	Parse(ctx context.Context, tokenString string) (user.User, error)
 	ParseState(ctx context.Context, tokenString string) (*jwt.OauthProxyClaims, error)
 	ParseFormState(ctx context.Context, tokenString string) (callbackURL string, responseID uuid.UUID, questionID uuid.UUID, redirectURL string, err error)
-	ParseLinkToken(ctx context.Context, tokenString string) (provider, providerID, existingProvider, existingProviderID, redirectURL string, userID uuid.UUID, err error)
+	ParseLinkToken(ctx context.Context, tokenString string) (*jwt.LinkClaims, error)
 	GenerateRefreshToken(ctx context.Context, userID uuid.UUID) (jwt.RefreshToken, error)
 	GetUserIDByRefreshToken(ctx context.Context, refreshTokenID uuid.UUID) (uuid.UUID, error)
 }
@@ -535,14 +535,20 @@ func (h *Handler) LinkAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	provider, providerID, existingProvider, existingProviderID, redirectURL, userID, err := h.jwtIssuer.ParseLinkToken(traceCtx, linkTokenStr)
+	linkClaims, err := h.jwtIssuer.ParseLinkToken(traceCtx, linkTokenStr)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidAuthHeaderFormat, logger)
+		return
+	}
+
+	userID, err := uuid.Parse(linkClaims.UserID)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidAuthHeaderFormat, logger)
 		return
 	}
 
 	// Link the new provider to the existing account.
-	err = h.userStore.CreateAuth(traceCtx, userID, provider, providerID, existingProvider, existingProviderID)
+	err = h.userStore.CreateAuth(traceCtx, userID, linkClaims.Provider, linkClaims.ProviderID, linkClaims.ExistingProvider, linkClaims.ExistingProviderID)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, err, logger)
 		return
@@ -558,7 +564,8 @@ func (h *Handler) LinkAccount(w http.ResponseWriter, r *http.Request) {
 
 	h.setAccessAndRefreshCookies(w, baseURL.Host, accessTokenID, refreshTokenID)
 
-	if redirectURL == "" {
+	var redirectURL string
+	if linkClaims.RedirectURL == "" {
 		if h.environment == "snapshot" || h.environment == "no-env" {
 			redirectURL = "/api/users/me"
 		} else {
@@ -594,7 +601,7 @@ func (h *Handler) LinkAccountAbort(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, _, _, _, redirectURL, _, err := h.jwtIssuer.ParseLinkToken(traceCtx, linkTokenStr)
+	linkClaims, err := h.jwtIssuer.ParseLinkToken(traceCtx, linkTokenStr)
 	if err != nil {
 		h.problemWriter.WriteError(traceCtx, w, internal.ErrInvalidAuthHeaderFormat, logger)
 		return
@@ -602,7 +609,8 @@ func (h *Handler) LinkAccountAbort(w http.ResponseWriter, r *http.Request) {
 
 	h.clearLinkCookie(w, domain)
 
-	if redirectURL == "" {
+	var redirectURL string
+	if linkClaims.RedirectURL == "" {
 		if h.environment == "snapshot" || h.environment == "no-env" {
 			redirectURL = "/api/users/me"
 		} else {

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -300,7 +300,7 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 		q.Set("name", result.ExistingName)
 		q.Set("oauthProvider", result.ExistingProvider)
 		q.Set("email", email)
-		redirectURL := "/link?" + q.Encode()
+		redirectURL := "/link-account?" + q.Encode()
 
 		http.Redirect(w, r, redirectURL, http.StatusFound)
 		return

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -296,14 +296,11 @@ func (h *Handler) Callback(w http.ResponseWriter, r *http.Request) {
 		}
 		h.setLinkCookie(w, baseURL.Host, linkToken)
 
-		redirectURL := redirectTo
-		if redirectURL == "" {
-			q := url.Values{}
-			q.Set("name", result.ExistingName)
-			q.Set("oauthProvider", result.ExistingProvider)
-			q.Set("email", email)
-			redirectURL = "/link?" + q.Encode()
-		}
+		q := url.Values{}
+		q.Set("name", result.ExistingName)
+		q.Set("oauthProvider", result.ExistingProvider)
+		q.Set("email", email)
+		redirectURL := "/link?" + q.Encode()
 
 		http.Redirect(w, r, redirectURL, http.StatusFound)
 		return

--- a/internal/jwt/service.go
+++ b/internal/jwt/service.go
@@ -439,7 +439,7 @@ func (s Service) NewLinkToken(ctx context.Context, provider, providerID, existin
 }
 
 // ParseLinkToken verifies a link token and returns its claims.
-func (s Service) ParseLinkToken(ctx context.Context, tokenString string) (*LinkClaims, error) {
+func (s Service) ParseLinkToken(ctx context.Context, tokenString string) (*LinkClaims, uuid.UUID, error) {
 	traceCtx, span := s.tracer.Start(ctx, "ParseLinkToken")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -468,14 +468,20 @@ func (s Service) ParseLinkToken(ctx context.Context, tokenString string) (*LinkC
 		default:
 			logger.Error("Failed to parse link token", zap.Error(parseErr))
 		}
-		return nil, parseErr
+		return nil, uuid.UUID{}, parseErr
+	}
+
+	userID, err := uuid.Parse(tokenClaims.UserID)
+	if err != nil {
+		logger.Error("failed to parse user id from link token", zap.String("error", err.Error()))
+		return nil, uuid.UUID{}, err
 	}
 
 	logger.Debug("Successfully parsed link token",
 		zap.String("provider", tokenClaims.Provider),
 		zap.String("existing_provider", tokenClaims.ExistingProvider),
 	)
-	return tokenClaims, nil
+	return tokenClaims, userID, nil
 }
 
 func (s Service) GetUserIDByRefreshToken(ctx context.Context, id uuid.UUID) (uuid.UUID, error) {

--- a/internal/jwt/service.go
+++ b/internal/jwt/service.go
@@ -394,6 +394,9 @@ type LinkClaims struct {
 	// ExistingProviderID is the provider-specific ID already associated with the existing account.
 	ExistingProviderID string
 
+	// RedirectURL preserves the original destination to prevent it from being overwritten by the account-linking flow.
+	RedirectURL string
+
 	jwt.RegisteredClaims
 }
 
@@ -401,7 +404,7 @@ type LinkClaims struct {
 // OAuth identity when it collides with an existing account's email.
 // The token is placed in an HttpOnly cookie so the frontend can later call
 // /api/auth/link to confirm the account merge.
-func (s Service) NewLinkToken(ctx context.Context, provider, providerID, existingProvider, existingProviderID, userID string) (string, error) {
+func (s Service) NewLinkToken(ctx context.Context, provider, providerID, existingProvider, existingProviderID, redirectURL, userID string) (string, error) {
 	traceCtx, span := s.tracer.Start(ctx, "NewLinkToken")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -413,6 +416,7 @@ func (s Service) NewLinkToken(ctx context.Context, provider, providerID, existin
 		UserID:             userID,
 		ExistingProvider:   existingProvider,
 		ExistingProviderID: existingProviderID,
+		RedirectURL:        redirectURL,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    Issuer,
 			Subject:   id.String(),
@@ -435,7 +439,7 @@ func (s Service) NewLinkToken(ctx context.Context, provider, providerID, existin
 }
 
 // ParseLinkToken verifies a link token and returns its claims.
-func (s Service) ParseLinkToken(ctx context.Context, tokenString string) (provider, providerID, existingProvider, existingProviderID string, userID uuid.UUID, err error) {
+func (s Service) ParseLinkToken(ctx context.Context, tokenString string) (provider, providerID, existingProvider, existingProviderID, redirectURL string, userID uuid.UUID, err error) {
 	traceCtx, span := s.tracer.Start(ctx, "ParseLinkToken")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -464,20 +468,20 @@ func (s Service) ParseLinkToken(ctx context.Context, tokenString string) (provid
 		default:
 			logger.Error("Failed to parse link token", zap.Error(parseErr))
 		}
-		return "", "", "", "", uuid.UUID{}, parseErr
+		return "", "", "", "", "", uuid.UUID{}, parseErr
 	}
 
 	userID, err = uuid.Parse(tokenClaims.UserID)
 	if err != nil {
 		logger.Error("Failed to parse user id from link token", zap.String("user_id", tokenClaims.UserID), zap.Error(err))
-		return "", "", "", "", uuid.UUID{}, err
+		return "", "", "", "", "", uuid.UUID{}, err
 	}
 
 	logger.Debug("Successfully parsed link token",
 		zap.String("provider", tokenClaims.Provider),
 		zap.String("existing_provider", tokenClaims.ExistingProvider),
 	)
-	return tokenClaims.Provider, tokenClaims.ProviderID, tokenClaims.ExistingProvider, tokenClaims.ExistingProviderID, userID, nil
+	return tokenClaims.Provider, tokenClaims.ProviderID, tokenClaims.ExistingProvider, tokenClaims.ExistingProviderID, tokenClaims.RedirectURL, userID, nil
 }
 
 func (s Service) GetUserIDByRefreshToken(ctx context.Context, id uuid.UUID) (uuid.UUID, error) {

--- a/internal/jwt/service.go
+++ b/internal/jwt/service.go
@@ -439,7 +439,7 @@ func (s Service) NewLinkToken(ctx context.Context, provider, providerID, existin
 }
 
 // ParseLinkToken verifies a link token and returns its claims.
-func (s Service) ParseLinkToken(ctx context.Context, tokenString string) (provider, providerID, existingProvider, existingProviderID, redirectURL string, userID uuid.UUID, err error) {
+func (s Service) ParseLinkToken(ctx context.Context, tokenString string) (*LinkClaims, error) {
 	traceCtx, span := s.tracer.Start(ctx, "ParseLinkToken")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
@@ -468,20 +468,14 @@ func (s Service) ParseLinkToken(ctx context.Context, tokenString string) (provid
 		default:
 			logger.Error("Failed to parse link token", zap.Error(parseErr))
 		}
-		return "", "", "", "", "", uuid.UUID{}, parseErr
-	}
-
-	userID, err = uuid.Parse(tokenClaims.UserID)
-	if err != nil {
-		logger.Error("Failed to parse user id from link token", zap.String("user_id", tokenClaims.UserID), zap.Error(err))
-		return "", "", "", "", "", uuid.UUID{}, err
+		return nil, parseErr
 	}
 
 	logger.Debug("Successfully parsed link token",
 		zap.String("provider", tokenClaims.Provider),
 		zap.String("existing_provider", tokenClaims.ExistingProvider),
 	)
-	return tokenClaims.Provider, tokenClaims.ProviderID, tokenClaims.ExistingProvider, tokenClaims.ExistingProviderID, tokenClaims.RedirectURL, userID, nil
+	return tokenClaims, nil
 }
 
 func (s Service) GetUserIDByRefreshToken(ctx context.Context, id uuid.UUID) (uuid.UUID, error) {


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Rename routes to `/link-account` for readability.
- Use `/link-account` route with query params for cases when `redirectTo` is not set.
- Whether or not to link account, the user will always be redirected back to their page.

## Additional Information
Currently, the redirect parameter (r) serves two distinct purposes:

1. Standard Login (A/B/C flows): It currently defaults to `/callback`, which is redundant. Front-end team plan to phase this out or reserve it strictly for "return to home page" scenarios. The frontend now handles branching to `/`,` /forms`, `/welcome`, or `/link-account` based on the login result.

2. Form OAuth Popups: This is the primary use case where r contains essential frontend callback URLs (e.g., `/forms/oauth-callback?questionId=...`).

In the **Account Linking (Flow C)** specifically, the frontend will prioritize the backend-provided URL to ensure the user is correctly guided to the linking interface. Backend will preserve the `redirectURL` when login, such that the users are able to return back to their page.