### PR TITLE
[CORE-290] Update Parent Org/Unit Permission Chain

### DIFF
--- a/internal/auth/middleware/unit_role_middleware.go
+++ b/internal/auth/middleware/unit_role_middleware.go
@@ -21,6 +21,7 @@ import (
 
 type UnitRoleService interface {
 	GetMemberRole(ctx context.Context, unitID uuid.UUID, memberID uuid.UUID) (unit.UnitRole, error)
+	GetUnitAncestorIDs(ctx context.Context, unitID uuid.UUID) ([]uuid.UUID, error)
 }
 
 type UnitRoleMiddleware struct {
@@ -80,6 +81,43 @@ func (m *UnitRoleMiddleware) checkRole(
 		return
 	}
 
+	// check ancestor admin
+	ancestors, err := m.service.GetUnitAncestorIDs(traceCtx, unitID)
+	if err != nil {
+		logger.Error("failed to get unit ancestors",
+			zap.String("user_id", u.ID.String()),
+			zap.String("unit_id", unitID.String()),
+			zap.Error(err),
+		)
+
+		m.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	for _, ancestorID := range ancestors {
+		dbRole, err := m.service.GetMemberRole(traceCtx, ancestorID, u.ID)
+		if err != nil {
+			if errors.Is(err, internal.ErrNotFound) {
+				continue
+			}
+
+			logger.Error("failed to get ancestor member role",
+				zap.String("user_id", u.ID.String()),
+				zap.String("unit_id", unitID.String()),
+				zap.Error(err),
+			)
+
+			m.problemWriter.WriteError(traceCtx, w, err, logger)
+			return
+		}
+
+		if dbRole == unit.UnitRoleAdmin {
+			next(w, r)
+			return
+		}
+	}
+
+	// check current unit role
 	dbRole, err := m.service.GetMemberRole(traceCtx, unitID, u.ID)
 	if err != nil {
 		if errors.Is(err, internal.ErrNotFound) {

--- a/internal/auth/middleware/unit_role_middleware.go
+++ b/internal/auth/middleware/unit_role_middleware.go
@@ -21,7 +21,7 @@ import (
 
 type UnitRoleService interface {
 	GetMemberRole(ctx context.Context, unitID uuid.UUID, memberID uuid.UUID) (unit.UnitRole, error)
-	GetUnitAncestorByID(ctx context.Context, unitID uuid.UUID) ([]uuid.UUID, error)
+	HasAdminInAncestorUnits(ctx context.Context, unitID uuid.UUID, userID uuid.UUID) (bool, error)
 }
 
 type UnitRoleMiddleware struct {
@@ -82,9 +82,9 @@ func (m *UnitRoleMiddleware) checkRole(
 	}
 
 	// check ancestor admin
-	ancestors, err := m.service.GetUnitAncestorByID(traceCtx, unitID)
+	hasAdmin, err := m.service.HasAdminInAncestorUnits(traceCtx, unitID, u.ID)
 	if err != nil {
-		logger.Error("failed to get unit ancestors",
+		logger.Error("failed to check ancestor units admin",
 			zap.String("user_id", u.ID.String()),
 			zap.String("unit_id", unitID.String()),
 			zap.Error(err),
@@ -94,27 +94,9 @@ func (m *UnitRoleMiddleware) checkRole(
 		return
 	}
 
-	for _, ancestorID := range ancestors {
-		dbRole, err := m.service.GetMemberRole(traceCtx, ancestorID, u.ID)
-		if err != nil {
-			if errors.Is(err, internal.ErrNotFound) {
-				continue
-			}
-
-			logger.Error("failed to get ancestor member role",
-				zap.String("user_id", u.ID.String()),
-				zap.String("unit_id", unitID.String()),
-				zap.Error(err),
-			)
-
-			m.problemWriter.WriteError(traceCtx, w, err, logger)
-			return
-		}
-
-		if dbRole == unit.UnitRoleAdmin {
-			next(w, r)
-			return
-		}
+	if hasAdmin {
+		next(w, r)
+		return
 	}
 
 	// check current unit role

--- a/internal/auth/middleware/unit_role_middleware.go
+++ b/internal/auth/middleware/unit_role_middleware.go
@@ -21,7 +21,7 @@ import (
 
 type UnitRoleService interface {
 	GetMemberRole(ctx context.Context, unitID uuid.UUID, memberID uuid.UUID) (unit.UnitRole, error)
-	GetUnitAncestorIDs(ctx context.Context, unitID uuid.UUID) ([]uuid.UUID, error)
+	GetUnitAncestorByID(ctx context.Context, unitID uuid.UUID) ([]uuid.UUID, error)
 }
 
 type UnitRoleMiddleware struct {
@@ -82,7 +82,7 @@ func (m *UnitRoleMiddleware) checkRole(
 	}
 
 	// check ancestor admin
-	ancestors, err := m.service.GetUnitAncestorIDs(traceCtx, unitID)
+	ancestors, err := m.service.GetUnitAncestorByID(traceCtx, unitID)
 	if err != nil {
 		logger.Error("failed to get unit ancestors",
 			zap.String("user_id", u.ID.String()),

--- a/internal/database/full_schema.sql
+++ b/internal/database/full_schema.sql
@@ -2,12 +2,37 @@
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
-CREATE TABLE IF NOT EXISTS refresh_tokens (
+CREATE TABLE IF NOT EXISTS files (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    is_active BOOLEAN DEFAULT TRUE,
-    expiration_date TIMESTAMPTZ NOT NULL
-);CREATE TYPE db_strategy AS ENUM ('shared', 'isolated');
+    original_filename VARCHAR(255) NOT NULL,
+    content_type VARCHAR(100) NOT NULL,
+    size BIGINT NOT NULL,
+    data BYTEA NOT NULL,
+    uploaded_by UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_files_uploaded_by ON files(uploaded_by);
+CREATE INDEX IF NOT EXISTS idx_files_created_at ON files(created_at);
+
+CREATE TYPE resource_type AS ENUM(
+    'form_answer'
+);
+
+CREATE TABLE IF NOT EXISTS file_attachments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    file_id UUID NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+    resource_type resource_type NOT NULL,
+    resource_id UUID NOT NULL,
+    created_by UUID NOT NULL REFERENCES users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(file_id, resource_type, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_file_attachments_file_id ON file_attachments(file_id);
+CREATE INDEX IF NOT EXISTS idx_file_attachments_resource ON file_attachments(resource_type, resource_id);
+CREATE TYPE db_strategy AS ENUM ('shared', 'isolated');
 
 CREATE TABLE IF NOT EXISTS tenants
 (
@@ -23,42 +48,7 @@ CREATE TABLE IF NOT EXISTS slug_history
     org_id UUID REFERENCES units(id) ON DELETE CASCADE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     ended_at TIMESTAMPTZ DEFAULT null
-);CREATE EXTENSION IF NOT EXISTS pgcrypto;
-
-CREATE TYPE unit_type AS ENUM ('organization', 'unit');
-
-CREATE TABLE IF NOT EXISTS units (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    org_id UUID REFERENCES units(id),
-    parent_id UUID REFERENCES units(id) ON DELETE SET NULL,
-    type unit_type NOT NULL DEFAULT 'unit',
-    name VARCHAR(255),
-    description VARCHAR(255),
-    metadata JSONB,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
-CREATE INDEX idx_units_parent_id ON units(parent_id);
-
-CREATE TYPE unit_role AS ENUM ('admin', 'member');
-
-CREATE TABLE IF NOT EXISTS unit_members (
-    unit_id UUID REFERENCES units(id) ON DELETE CASCADE,
-    member_id UUID,
-    role unit_role NOT NULL DEFAULT 'member',
-    PRIMARY KEY (unit_id, member_id)
-);
-CREATE TABLE IF NOT EXISTS answers (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    response_id UUID NOT NULL REFERENCES form_responses(id) ON DELETE CASCADE,
-    question_id UUID NOT NULL REFERENCES questions(id) ON DELETE CASCADE,
-    value JSONB NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    UNIQUE(response_id, question_id)
-);
-CREATE TYPE response_progress AS ENUM (
+);CREATE TYPE response_progress AS ENUM (
     'draft',
     'submitted'
 );
@@ -124,6 +114,15 @@ CREATE TABLE IF NOT EXISTS sections (
 
 CREATE INDEX idx_sections_form_id ON sections(form_id);
 
+CREATE TABLE IF NOT EXISTS answers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    response_id UUID NOT NULL REFERENCES form_responses(id) ON DELETE CASCADE,
+    question_id UUID NOT NULL REFERENCES questions(id) ON DELETE CASCADE,
+    value JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(response_id, question_id)
+);
 CREATE TYPE question_type AS ENUM(
     'short_text',
     'long_text',
@@ -173,60 +172,6 @@ CREATE TABLE IF NOT EXISTS workflow_versions (
 CREATE INDEX idx_workflow_versions_is_active ON workflow_versions(form_id, is_active) WHERE is_active = true;
 
 CREATE INDEX idx_workflow_versions_latest ON workflow_versions(form_id, updated_at DESC);
-CREATE TYPE content_type AS ENUM(
-    'text',
-    'form'
-);
-
-CREATE TABLE IF NOT EXISTS inbox_message(
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    posted_by UUID NOT NULL references units(id),
-    type content_type NOT NULL,
-    content_id UUID NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT now(),
-    updated_at TIMESTAMP NOT NULL DEFAULT now()
-);
-
-CREATE TABLE IF NOT EXISTS user_inbox_messages (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL references users(id) ON DELETE CASCADE,
-    message_id UUID NOT NULL references inbox_message(id) ON DELETE CASCADE,
-    is_read boolean NOT NULL DEFAULT false,
-    is_starred boolean NOT NULL DEFAULT false,
-    is_archived boolean NOT NULL DEFAULT false
-);
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
-
-CREATE TABLE IF NOT EXISTS files (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    original_filename VARCHAR(255) NOT NULL,
-    content_type VARCHAR(100) NOT NULL,
-    size BIGINT NOT NULL,
-    data BYTEA NOT NULL,
-    uploaded_by UUID,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
-CREATE INDEX IF NOT EXISTS idx_files_uploaded_by ON files(uploaded_by);
-CREATE INDEX IF NOT EXISTS idx_files_created_at ON files(created_at);
-
-CREATE TYPE resource_type AS ENUM(
-    'form_answer'
-);
-
-CREATE TABLE IF NOT EXISTS file_attachments (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    file_id UUID NOT NULL REFERENCES files(id) ON DELETE CASCADE,
-    resource_type resource_type NOT NULL,
-    resource_id UUID NOT NULL,
-    created_by UUID NOT NULL REFERENCES users(id),
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    UNIQUE(file_id, resource_type, resource_id)
-);
-
-CREATE INDEX IF NOT EXISTS idx_file_attachments_file_id ON file_attachments(file_id);
-CREATE INDEX IF NOT EXISTS idx_file_attachments_resource ON file_attachments(resource_type, resource_id);
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 CREATE TABLE IF NOT EXISTS users (
@@ -271,4 +216,58 @@ SELECT
     COALESCE(array_agg(e.value) FILTER (WHERE e.value IS NOT NULL), ARRAY[]::text[]) as emails
 FROM users u
 LEFT JOIN user_emails e ON u.id = e.user_id
-GROUP BY u.id, u.name, u.username, u.avatar_url, u.role, u.is_onboarded, u.created_at, u.updated_at;
+GROUP BY u.id, u.name, u.username, u.avatar_url, u.role, u.is_onboarded, u.created_at, u.updated_at;CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    is_active BOOLEAN DEFAULT TRUE,
+    expiration_date TIMESTAMPTZ NOT NULL
+);CREATE TYPE content_type AS ENUM(
+    'text',
+    'form'
+);
+
+CREATE TABLE IF NOT EXISTS inbox_message(
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    posted_by UUID NOT NULL references units(id),
+    type content_type NOT NULL,
+    content_id UUID NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS user_inbox_messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL references users(id) ON DELETE CASCADE,
+    message_id UUID NOT NULL references inbox_message(id) ON DELETE CASCADE,
+    is_read boolean NOT NULL DEFAULT false,
+    is_starred boolean NOT NULL DEFAULT false,
+    is_archived boolean NOT NULL DEFAULT false
+);
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TYPE unit_type AS ENUM ('organization', 'unit');
+
+CREATE TABLE IF NOT EXISTS units (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id UUID REFERENCES units(id),
+    parent_id UUID REFERENCES units(id) ON DELETE SET NULL,
+    type unit_type NOT NULL DEFAULT 'unit',
+    name VARCHAR(255),
+    description VARCHAR(255),
+    metadata JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_units_parent_id ON units(parent_id);
+
+CREATE TYPE unit_role AS ENUM ('admin', 'member');
+
+CREATE TABLE IF NOT EXISTS unit_members (
+    unit_id UUID REFERENCES units(id) ON DELETE CASCADE,
+    member_id UUID,
+    role unit_role NOT NULL DEFAULT 'member',
+    PRIMARY KEY (unit_id, member_id)
+);

--- a/internal/unit/queries.sql
+++ b/internal/unit/queries.sql
@@ -129,3 +129,18 @@ VALUES ($1, $2, $3)
 DO UPDATE SET
     role = EXCLUDED.role
 RETURNING unit_id, member_id, role;
+
+-- name: GetUnitAncestorIDs :many
+WITH RECURSIVE ancestors(id, parent_id) AS (
+    SELECT u.id, u.parent_id
+    FROM units u
+    WHERE u.id = $1
+
+    UNION
+
+    SELECT u.id, u.parent_id
+    FROM units u
+             INNER JOIN ancestors a ON u.id = a.parent_id
+)
+SELECT a.id
+FROM ancestors a;

--- a/internal/unit/queries.sql
+++ b/internal/unit/queries.sql
@@ -131,16 +131,18 @@ DO UPDATE SET
 RETURNING unit_id, member_id, role;
 
 -- name: GetUnitAncestorIDs :many
-WITH RECURSIVE ancestors(id, parent_id) AS (
-    SELECT u.id, u.parent_id
+WITH RECURSIVE ancestors(ancestor_id) AS (
+    SELECT parent_id
     FROM units u
     WHERE u.id = $1
+      AND u.parent_id IS NOT NULL
 
     UNION
 
-    SELECT u.id, u.parent_id
+    SELECT u.parent_id
     FROM units u
-             INNER JOIN ancestors a ON u.id = a.parent_id
+             JOIN ancestors a ON u.id = a.ancestor_id
+    WHERE u.parent_id IS NOT NULL
 )
-SELECT a.id
-FROM ancestors a;
+SELECT ancestor_id
+FROM ancestors;

--- a/internal/unit/queries.sql
+++ b/internal/unit/queries.sql
@@ -130,19 +130,24 @@ DO UPDATE SET
     role = EXCLUDED.role
 RETURNING unit_id, member_id, role;
 
--- name: GetUnitAncestorIDs :many
-WITH RECURSIVE ancestors(ancestor_id) AS (
+-- name: HasAdminInAncestorUnits :one
+WITH RECURSIVE ancestors(unit_id) AS (
     SELECT parent_id
     FROM units u
     WHERE u.id = $1
       AND u.parent_id IS NOT NULL
 
-    UNION
+    UNION ALL
 
     SELECT u.parent_id
     FROM units u
-             JOIN ancestors a ON u.id = a.ancestor_id
+             JOIN ancestors a ON u.id = a.unit_id
     WHERE u.parent_id IS NOT NULL
 )
-SELECT ancestor_id
-FROM ancestors;
+SELECT EXISTS (
+    SELECT 1
+    FROM ancestors a
+             JOIN unit_members um ON um.unit_id = a.unit_id
+    WHERE um.member_id = $2
+      AND um.role = 'admin'
+) AS has_admin;

--- a/internal/unit/queries.sql.go
+++ b/internal/unit/queries.sql.go
@@ -288,42 +288,39 @@ func (q *Queries) GetOrganizationByIDWithSlug(ctx context.Context, id uuid.UUID)
 	return i, err
 }
 
-const getUnitAncestorIDs = `-- name: GetUnitAncestorIDs :many
-WITH RECURSIVE ancestors(ancestor_id) AS (
+const hasAdminInAncestorUnits = `-- name: HasAdminInAncestorUnits :one
+WITH RECURSIVE ancestors(unit_id) AS (
     SELECT parent_id
     FROM units u
     WHERE u.id = $1
       AND u.parent_id IS NOT NULL
 
-    UNION
+    UNION ALL
 
     SELECT u.parent_id
     FROM units u
-             JOIN ancestors a ON u.id = a.ancestor_id
+             JOIN ancestors a ON u.id = a.unit_id
     WHERE u.parent_id IS NOT NULL
 )
-SELECT ancestor_id
-FROM ancestors
+SELECT EXISTS (
+    SELECT 1
+    FROM ancestors a
+             JOIN unit_members um ON um.unit_id = a.unit_id
+    WHERE um.member_id = $2
+      AND um.role = 'admin'
+) AS has_admin
 `
 
-func (q *Queries) GetUnitAncestorIDs(ctx context.Context, id uuid.UUID) ([]pgtype.UUID, error) {
-	rows, err := q.db.Query(ctx, getUnitAncestorIDs, id)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []pgtype.UUID
-	for rows.Next() {
-		var ancestor_id pgtype.UUID
-		if err := rows.Scan(&ancestor_id); err != nil {
-			return nil, err
-		}
-		items = append(items, ancestor_id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
+type HasAdminInAncestorUnitsParams struct {
+	ID       uuid.UUID
+	MemberID uuid.UUID
+}
+
+func (q *Queries) HasAdminInAncestorUnits(ctx context.Context, arg HasAdminInAncestorUnitsParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasAdminInAncestorUnits, arg.ID, arg.MemberID)
+	var has_admin bool
+	err := row.Scan(&has_admin)
+	return has_admin, err
 }
 
 const listMembers = `-- name: ListMembers :many

--- a/internal/unit/queries.sql.go
+++ b/internal/unit/queries.sql.go
@@ -288,6 +288,42 @@ func (q *Queries) GetOrganizationByIDWithSlug(ctx context.Context, id uuid.UUID)
 	return i, err
 }
 
+const getUnitAncestorIDs = `-- name: GetUnitAncestorIDs :many
+WITH RECURSIVE ancestors(id, parent_id) AS (
+    SELECT u.id, u.parent_id
+    FROM units u
+    WHERE u.id = $1
+
+    UNION
+
+    SELECT u.id, u.parent_id
+    FROM units u
+             INNER JOIN ancestors a ON u.id = a.parent_id
+)
+SELECT a.id
+FROM ancestors a
+`
+
+func (q *Queries) GetUnitAncestorIDs(ctx context.Context, id uuid.UUID) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, getUnitAncestorIDs, id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listMembers = `-- name: ListMembers :many
 SELECT m.member_id,
        m.role,

--- a/internal/unit/queries.sql.go
+++ b/internal/unit/queries.sql.go
@@ -289,34 +289,36 @@ func (q *Queries) GetOrganizationByIDWithSlug(ctx context.Context, id uuid.UUID)
 }
 
 const getUnitAncestorIDs = `-- name: GetUnitAncestorIDs :many
-WITH RECURSIVE ancestors(id, parent_id) AS (
-    SELECT u.id, u.parent_id
+WITH RECURSIVE ancestors(ancestor_id) AS (
+    SELECT parent_id
     FROM units u
     WHERE u.id = $1
+      AND u.parent_id IS NOT NULL
 
     UNION
 
-    SELECT u.id, u.parent_id
+    SELECT u.parent_id
     FROM units u
-             INNER JOIN ancestors a ON u.id = a.parent_id
+             JOIN ancestors a ON u.id = a.ancestor_id
+    WHERE u.parent_id IS NOT NULL
 )
-SELECT a.id
-FROM ancestors a
+SELECT ancestor_id
+FROM ancestors
 `
 
-func (q *Queries) GetUnitAncestorIDs(ctx context.Context, id uuid.UUID) ([]uuid.UUID, error) {
+func (q *Queries) GetUnitAncestorIDs(ctx context.Context, id uuid.UUID) ([]pgtype.UUID, error) {
 	rows, err := q.db.Query(ctx, getUnitAncestorIDs, id)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []uuid.UUID
+	var items []pgtype.UUID
 	for rows.Next() {
-		var id uuid.UUID
-		if err := rows.Scan(&id); err != nil {
+		var ancestor_id pgtype.UUID
+		if err := rows.Scan(&ancestor_id); err != nil {
 			return nil, err
 		}
-		items = append(items, id)
+		items = append(items, ancestor_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/unit/service.go
+++ b/internal/unit/service.go
@@ -41,7 +41,7 @@ type Querier interface {
 	GetMemberRole(ctx context.Context, arg GetMemberRoleParams) (UnitRole, error)
 	UpdateMemberRole(ctx context.Context, arg UpdateMemberRoleParams) error
 	LockAdminsForUnit(ctx context.Context, unitID uuid.UUID) ([]uuid.UUID, error)
-	GetUnitAncestorIDs(ctx context.Context, unitID uuid.UUID) ([]pgtype.UUID, error)
+	HasAdminInAncestorUnits(ctx context.Context, arg HasAdminInAncestorUnitsParams) (bool, error)
 
 	WithTx(tx pgx.Tx) *Queries
 }
@@ -691,30 +691,26 @@ func (s *Service) GetOrgIDBySlug(ctx context.Context, slug string) (uuid.UUID, e
 	return orgID, nil
 }
 
-func (s *Service) GetUnitAncestorByID(ctx context.Context, unitID uuid.UUID) ([]uuid.UUID, error) {
-	traceCtx, span := s.tracer.Start(ctx, "GetUnitAncestorByID")
+func (s *Service) HasAdminInAncestorUnits(ctx context.Context, unitID uuid.UUID, userID uuid.UUID) (bool, error) {
+	traceCtx, span := s.tracer.Start(ctx, "HasAdminInAncestorUnits")
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	rows, err := s.queries.GetUnitAncestorIDs(traceCtx, unitID)
+	has, err := s.queries.HasAdminInAncestorUnits(traceCtx, HasAdminInAncestorUnitsParams{
+		ID:       unitID,
+		MemberID: userID,
+	})
 	if err != nil {
-		err = databaseutil.WrapDBError(err, logger, "get unit ancestor by id")
+		err = databaseutil.WrapDBError(err, logger, "Check Admin In Ancestor Units")
 		span.RecordError(err)
-		return nil, err
+		return false, err
 	}
 
-	ids := make([]uuid.UUID, 0, len(rows))
-	for _, row := range rows {
-		if !row.Valid {
-			continue
-		}
-		ids = append(ids, row.Bytes)
-	}
-
-	logger.Info("Get unit ancestor by ID",
+	logger.Info("Check Admin In Ancestor Units",
 		zap.String("unit_id", unitID.String()),
-		zap.Int("count", len(ids)),
+		zap.String("user_id", userID.String()),
+		zap.Bool("has_admin_in_ancestor_units", has),
 	)
 
-	return ids, nil
+	return has, nil
 }

--- a/internal/unit/service.go
+++ b/internal/unit/service.go
@@ -41,7 +41,7 @@ type Querier interface {
 	GetMemberRole(ctx context.Context, arg GetMemberRoleParams) (UnitRole, error)
 	UpdateMemberRole(ctx context.Context, arg UpdateMemberRoleParams) error
 	LockAdminsForUnit(ctx context.Context, unitID uuid.UUID) ([]uuid.UUID, error)
-	GetUnitAncestorIDs(ctx context.Context, unitID uuid.UUID) ([]uuid.UUID, error)
+	GetUnitAncestorIDs(ctx context.Context, unitID uuid.UUID) ([]pgtype.UUID, error)
 
 	WithTx(tx pgx.Tx) *Queries
 }
@@ -696,15 +696,19 @@ func (s *Service) GetUnitAncestorByID(ctx context.Context, unitID uuid.UUID) ([]
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	ids, err := s.queries.GetUnitAncestorIDs(traceCtx, unitID)
+	rows, err := s.queries.GetUnitAncestorIDs(traceCtx, unitID)
 	if err != nil {
 		err = databaseutil.WrapDBError(err, logger, "get unit ancestor by id")
 		span.RecordError(err)
 		return nil, err
 	}
 
-	if ids == nil {
-		ids = []uuid.UUID{}
+	ids := make([]uuid.UUID, 0, len(rows))
+	for _, row := range rows {
+		if !row.Valid {
+			continue
+		}
+		ids = append(ids, row.Bytes)
 	}
 
 	logger.Info("Get unit ancestor by ID",

--- a/internal/unit/service.go
+++ b/internal/unit/service.go
@@ -41,6 +41,7 @@ type Querier interface {
 	GetMemberRole(ctx context.Context, arg GetMemberRoleParams) (UnitRole, error)
 	UpdateMemberRole(ctx context.Context, arg UpdateMemberRoleParams) error
 	LockAdminsForUnit(ctx context.Context, unitID uuid.UUID) ([]uuid.UUID, error)
+	GetUnitAncestorIDs(ctx context.Context, unitID uuid.UUID) ([]uuid.UUID, error)
 
 	WithTx(tx pgx.Tx) *Queries
 }
@@ -688,4 +689,28 @@ func (s *Service) GetOrgIDBySlug(ctx context.Context, slug string) (uuid.UUID, e
 		return uuid.UUID{}, fmt.Errorf("organization with slug %q not found", slug)
 	}
 	return orgID, nil
+}
+
+func (s *Service) GetUnitAncestorByID(ctx context.Context, unitID uuid.UUID) ([]uuid.UUID, error) {
+	traceCtx, span := s.tracer.Start(ctx, "GetUnitAncestorByID")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, s.logger)
+
+	ids, err := s.queries.GetUnitAncestorIDs(traceCtx, unitID)
+	if err != nil {
+		err = databaseutil.WrapDBError(err, logger, "get unit ancestor by id")
+		span.RecordError(err)
+		return nil, err
+	}
+
+	if ids == nil {
+		ids = []uuid.UUID{}
+	}
+
+	logger.Info("Get unit ancestor by ID",
+		zap.String("unit_id", unitID.String()),
+		zap.Int("count", len(ids)),
+	)
+
+	return ids, nil
 }

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -2,12 +2,12 @@
 version: "2"
 sql:
   - engine: "postgresql"
-    queries: "./internal/jwt/queries.sql"
+    queries: "./internal/file/queries.sql"
     schema: "./internal/database/full_schema.sql"
     gen:
       go:
-        package: "jwt"
-        out: "./internal/jwt"
+        package: "file"
+        out: "./internal/file"
         sql_package: "pgx/v5"
         overrides:
           - db_type: "uuid"
@@ -28,12 +28,12 @@ sql:
               import: "github.com/google/uuid"
               type: "UUID"
   - engine: "postgresql"
-    queries: "./internal/unit/queries.sql"
+    queries: "./internal/form/response/queries.sql"
     schema: "./internal/database/full_schema.sql"
     gen:
       go:
-        package: "unit"
-        out: "./internal/unit"
+        package: "response"
+        out: "./internal/form/response"
         sql_package: "pgx/v5"
         overrides:
           - db_type: "uuid"
@@ -54,12 +54,12 @@ sql:
               import: "github.com/google/uuid"
               type: "UUID"
   - engine: "postgresql"
-    queries: "./internal/form/response/queries.sql"
+    queries: "./internal/form/queries.sql"
     schema: "./internal/database/full_schema.sql"
     gen:
       go:
-        package: "response"
-        out: "./internal/form/response"
+        package: "form"
+        out: "./internal/form"
         sql_package: "pgx/v5"
         overrides:
           - db_type: "uuid"
@@ -93,12 +93,25 @@ sql:
               import: "github.com/google/uuid"
               type: "UUID"
   - engine: "postgresql"
-    queries: "./internal/form/queries.sql"
+    queries: "./internal/user/queries.sql"
     schema: "./internal/database/full_schema.sql"
     gen:
       go:
-        package: "form"
-        out: "./internal/form"
+        package: "user"
+        out: "./internal/user"
+        sql_package: "pgx/v5"
+        overrides:
+          - db_type: "uuid"
+            go_type:
+              import: "github.com/google/uuid"
+              type: "UUID"
+  - engine: "postgresql"
+    queries: "./internal/jwt/queries.sql"
+    schema: "./internal/database/full_schema.sql"
+    gen:
+      go:
+        package: "jwt"
+        out: "./internal/jwt"
         sql_package: "pgx/v5"
         overrides:
           - db_type: "uuid"
@@ -119,25 +132,12 @@ sql:
               import: "github.com/google/uuid"
               type: "UUID"
   - engine: "postgresql"
-    queries: "./internal/file/queries.sql"
+    queries: "./internal/unit/queries.sql"
     schema: "./internal/database/full_schema.sql"
     gen:
       go:
-        package: "file"
-        out: "./internal/file"
-        sql_package: "pgx/v5"
-        overrides:
-          - db_type: "uuid"
-            go_type:
-              import: "github.com/google/uuid"
-              type: "UUID"
-  - engine: "postgresql"
-    queries: "./internal/user/queries.sql"
-    schema: "./internal/database/full_schema.sql"
-    gen:
-      go:
-        package: "user"
-        out: "./internal/user"
+        package: "unit"
+        out: "./internal/unit"
         sql_package: "pgx/v5"
         overrides:
           - db_type: "uuid"


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add query and service to get unit ancestors
- Add checking parent admin permission in auth/middleware/unit_role_middleware


## Additional Information
- Only parent unit/org admin can pass auth middleware
- Parent unit/org member can not pass auth middleware