### PR TITLE
[CORE-360] Transation Centralization

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -55,6 +55,9 @@ var (
 	ErrInvalidJWTToken         = errors.New("invalid JWT token")
 	ErrInvalidAuthUser         = errors.New("invalid authenticated user")
 
+	// Database Errors
+	ErrDBTransactionNotSupported = errors.New("database connection does not support transactions")
+
 	// User Errors
 	ErrUserNotFound         = errors.New("user not found")
 	ErrNoUserInContext      = errors.New("no user found in request context")

--- a/internal/file/service.go
+++ b/internal/file/service.go
@@ -46,6 +46,13 @@ type ResourceHandler interface {
 	RemoveFileReference(ctx context.Context, fileID uuid.UUID, resourceID uuid.UUID) error
 }
 
+// TxResourceHandler is implemented by handlers that can run RemoveFileReference
+// on the same pgx.Tx as file.Service transactional operations.
+type TxResourceHandler interface {
+	ResourceHandler
+	WithTx(tx pgx.Tx) ResourceHandler
+}
+
 type Service struct {
 	logger           *zap.Logger
 	db               DBTX
@@ -85,9 +92,9 @@ func (s *Service) WithTx(tx pgx.Tx) *Service {
 // withTransaction runs fn inside a pgx transaction. If s.db is already a pgx.Tx, fn
 // runs on that transaction without begin/commit/rollback. Otherwise s.db must
 // implement TxBeginner.
-func (s *Service) withTransaction(ctx context.Context, fn func(*Queries) error) error {
+func (s *Service) withTransaction(ctx context.Context, fn func(tx pgx.Tx, qtx *Queries) error) error {
 	return internal.WithTransaction(ctx, s.db, s.logger, func(tx pgx.Tx) error {
-		return fn(s.queries.WithTx(tx))
+		return fn(tx, s.queries.WithTx(tx))
 	})
 }
 
@@ -163,7 +170,7 @@ func (s *Service) CreateAttachment(ctx context.Context, fileID uuid.UUID, resour
 
 	var attachment FileAttachment
 	var existingRecord bool
-	err := s.withTransaction(traceCtx, func(qtx *Queries) error {
+	err := s.withTransaction(traceCtx, func(_ pgx.Tx, qtx *Queries) error {
 		_, err := qtx.LockFile(traceCtx, fileID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -368,7 +375,7 @@ func (s *Service) Delete(ctx context.Context, fileID uuid.UUID) error {
 	logger := logutil.WithContext(traceCtx, s.logger)
 
 	var attachmentCount int
-	err := s.withTransaction(traceCtx, func(qtx *Queries) error {
+	err := s.withTransaction(traceCtx, func(tx pgx.Tx, qtx *Queries) error {
 		_, err := qtx.LockFile(traceCtx, fileID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -394,8 +401,13 @@ func (s *Service) Delete(ctx context.Context, fileID uuid.UUID) error {
 				span.RecordError(err)
 				return err
 			}
+			txHandler, ok := handler.(TxResourceHandler)
+			if ok {
+				handler = txHandler.WithTx(tx)
+			}
 
-			if err := handler.RemoveFileReference(traceCtx, fileID, att.ResourceID); err != nil {
+			err := handler.RemoveFileReference(traceCtx, fileID, att.ResourceID)
+			if err != nil {
 				err = fmt.Errorf(
 					"remove file reference from resource type %s resource id %s: %w",
 					att.ResourceType,
@@ -406,7 +418,7 @@ func (s *Service) Delete(ctx context.Context, fileID uuid.UUID) error {
 				return err
 			}
 
-			err := qtx.DeleteAttachment(traceCtx, att.ID)
+			err = qtx.DeleteAttachment(traceCtx, att.ID)
 			if err != nil {
 				err = databaseutil.WrapDBError(err, logger, "delete attachment after removing resource reference")
 				span.RecordError(err)

--- a/internal/file/service.go
+++ b/internal/file/service.go
@@ -50,7 +50,7 @@ type ResourceHandler interface {
 // on the same pgx.Tx as file.Service transactional operations.
 type TxResourceHandler interface {
 	ResourceHandler
-	WithTx(tx pgx.Tx) ResourceHandler
+	WithTx(tx pgx.Tx) (ResourceHandler, error)
 }
 
 type Service struct {
@@ -403,7 +403,18 @@ func (s *Service) Delete(ctx context.Context, fileID uuid.UUID) error {
 			}
 			txHandler, ok := handler.(TxResourceHandler)
 			if ok {
-				handler = txHandler.WithTx(tx)
+				var err error
+				handler, err = txHandler.WithTx(tx)
+				if err != nil {
+					err = fmt.Errorf(
+						"bind tx for resource type %s resource id %s: %w",
+						att.ResourceType,
+						att.ResourceID.String(),
+						err,
+					)
+					span.RecordError(err)
+					return err
+				}
 			}
 
 			err := handler.RemoveFileReference(traceCtx, fileID, att.ResourceID)

--- a/internal/file/service.go
+++ b/internal/file/service.go
@@ -41,10 +41,6 @@ type Querier interface {
 	WithTx(tx pgx.Tx) *Queries
 }
 
-type TxBeginner interface {
-	BeginTx(ctx context.Context, opts pgx.TxOptions) (pgx.Tx, error)
-}
-
 type ResourceHandler interface {
 	ResourceType() ResourceType
 	RemoveFileReference(ctx context.Context, fileID uuid.UUID, resourceID uuid.UUID) error
@@ -84,6 +80,15 @@ func (s *Service) WithTx(tx pgx.Tx) *Service {
 		validator:        s.validator,
 		resourceHandlers: s.resourceHandlers,
 	}
+}
+
+// withTransaction runs fn inside a pgx transaction. If s.db is already a pgx.Tx, fn
+// runs on that transaction without begin/commit/rollback. Otherwise s.db must
+// implement TxBeginner.
+func (s *Service) withTransaction(ctx context.Context, fn func(*Queries) error) error {
+	return internal.WithTransaction(ctx, s.db, s.logger, func(tx pgx.Tx) error {
+		return fn(s.queries.WithTx(tx))
+	})
 }
 
 // SaveFile saves the uploaded file data to database with validation
@@ -156,108 +161,72 @@ func (s *Service) CreateAttachment(ctx context.Context, fileID uuid.UUID, resour
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	var (
-		tx         pgx.Tx
-		err        error
-		needCommit bool
-	)
-
-	existingTx, ok := s.db.(pgx.Tx)
-	if ok {
-		tx = existingTx
-	} else {
-		beginner, ok := s.db.(TxBeginner)
-		if !ok {
-			return FileAttachment{}, fmt.Errorf("db does not support transactions")
-		}
-
-		tx, err = beginner.BeginTx(traceCtx, pgx.TxOptions{})
+	var attachment FileAttachment
+	var existingRecord bool
+	err := s.withTransaction(traceCtx, func(qtx *Queries) error {
+		_, err := qtx.LockFile(traceCtx, fileID)
 		if err != nil {
-			err = databaseutil.WrapDBError(err, logger, "begin tx for create attachment")
-			span.RecordError(err)
-			return FileAttachment{}, err
-		}
-		needCommit = true
-
-		defer func() {
-			err := tx.Rollback(traceCtx)
-			if err != nil && !errors.Is(err, pgx.ErrTxClosed) {
-				logger.Error("rollback failed", zap.Error(err))
+			if errors.Is(err, pgx.ErrNoRows) {
+				return internal.ErrFileNotFound
 			}
-		}()
-	}
-
-	qtx := s.queries.WithTx(tx)
-
-	_, err = qtx.LockFile(traceCtx, fileID)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return FileAttachment{}, internal.ErrFileNotFound
+			err = databaseutil.WrapDBError(err, logger, "lock file before create attachment")
+			span.RecordError(err)
+			return err
 		}
-		err = databaseutil.WrapDBError(err, logger, "lock file before create attachment")
+
+		created, err := qtx.CreateAttachment(traceCtx, CreateAttachmentParams{
+			FileID:       fileID,
+			ResourceType: resourceType,
+			ResourceID:   resourceID,
+			CreatedBy:    createdBy,
+		})
+		if err == nil {
+			attachment = created
+			return nil
+		}
+
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			existing, getErr := qtx.GetAttachmentByFileAndResource(traceCtx, GetAttachmentByFileAndResourceParams{
+				FileID:       fileID,
+				ResourceType: resourceType,
+				ResourceID:   resourceID,
+			})
+			if getErr != nil {
+				getErr = databaseutil.WrapDBError(getErr, logger, "get existing attachment after unique violation")
+				span.RecordError(getErr)
+				return getErr
+			}
+			attachment = existing
+			existingRecord = true
+			return nil
+		}
+
+		err = databaseutil.WrapDBError(err, logger, "create attachment")
 		span.RecordError(err)
+		return err
+	})
+	if err != nil {
 		return FileAttachment{}, err
 	}
 
-	attachment, err := qtx.CreateAttachment(traceCtx, CreateAttachmentParams{
-		FileID:       fileID,
-		ResourceType: resourceType,
-		ResourceID:   resourceID,
-		CreatedBy:    createdBy,
-	})
-	if err == nil {
-		if needCommit {
-			err := tx.Commit(traceCtx)
-			if err != nil {
-				err = databaseutil.WrapDBError(err, logger, "commit create attachment tx")
-				span.RecordError(err)
-				return FileAttachment{}, err
-			}
-		}
-
+	if existingRecord {
+		logger.Info("file attachment already exists, returning existing record",
+			zap.String("attachment_id", attachment.ID.String()),
+			zap.String("file_id", attachment.FileID.String()),
+			zap.String("resource_type", string(attachment.ResourceType)),
+			zap.String("resource_id", attachment.ResourceID.String()),
+		)
+	} else {
 		logger.Info("file attachment created",
 			zap.String("attachment_id", attachment.ID.String()),
 			zap.String("file_id", attachment.FileID.String()),
 			zap.String("resource_type", string(attachment.ResourceType)),
 			zap.String("resource_id", attachment.ResourceID.String()),
 		)
-		return attachment, nil
 	}
 
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-		existing, getErr := qtx.GetAttachmentByFileAndResource(traceCtx, GetAttachmentByFileAndResourceParams{
-			FileID:       fileID,
-			ResourceType: resourceType,
-			ResourceID:   resourceID,
-		})
-		if getErr != nil {
-			getErr = databaseutil.WrapDBError(getErr, logger, "get existing attachment after unique violation")
-			span.RecordError(getErr)
-			return FileAttachment{}, getErr
-		}
-
-		if needCommit {
-			err := tx.Commit(traceCtx)
-			if err != nil {
-				err = databaseutil.WrapDBError(err, logger, "commit create attachment tx")
-				span.RecordError(err)
-				return FileAttachment{}, err
-			}
-		}
-
-		logger.Info("file attachment already exists, returning existing record",
-			zap.String("attachment_id", existing.ID.String()),
-			zap.String("file_id", existing.FileID.String()),
-			zap.String("resource_type", string(existing.ResourceType)),
-			zap.String("resource_id", existing.ResourceID.String()),
-		)
-		return existing, nil
-	}
-
-	err = databaseutil.WrapDBError(err, logger, "create attachment")
-	span.RecordError(err)
-	return FileAttachment{}, err
+	return attachment, nil
 }
 
 // SaveFileForResource saves the file first, then creates the attachment
@@ -398,101 +367,69 @@ func (s *Service) Delete(ctx context.Context, fileID uuid.UUID) error {
 	defer span.End()
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	var (
-		tx         pgx.Tx
-		err        error
-		needCommit bool
-	)
-
-	existingTx, ok := s.db.(pgx.Tx)
-	if ok {
-		tx = existingTx
-	} else {
-		beginner, ok := s.db.(TxBeginner)
-		if !ok {
-			return fmt.Errorf("db does not support transactions")
-		}
-		tx, err = beginner.BeginTx(traceCtx, pgx.TxOptions{})
+	var attachmentCount int
+	err := s.withTransaction(traceCtx, func(qtx *Queries) error {
+		_, err := qtx.LockFile(traceCtx, fileID)
 		if err != nil {
-			err = databaseutil.WrapDBError(err, logger, "begin tx")
-			span.RecordError(err)
-			return err
-		}
-		needCommit = true
-
-		defer func() {
-			err := tx.Rollback(traceCtx)
-			if err != nil && !errors.Is(err, pgx.ErrTxClosed) {
-				logger.Error("rollback failed", zap.Error(err))
+			if errors.Is(err, pgx.ErrNoRows) {
+				return internal.ErrFileNotFound
 			}
-		}()
-	}
-
-	qtx := s.queries.WithTx(tx)
-
-	_, err = qtx.LockFile(traceCtx, fileID)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return internal.ErrFileNotFound
-		}
-		err = databaseutil.WrapDBError(err, logger, "lock file before delete")
-		span.RecordError(err)
-		return err
-	}
-
-	attachments, err := qtx.ListAttachmentsByFileID(traceCtx, fileID)
-	if err != nil {
-		err = databaseutil.WrapDBError(err, logger, "list attachments before delete file")
-		span.RecordError(err)
-		return err
-	}
-
-	for _, att := range attachments {
-		handler, ok := s.resourceHandlers[att.ResourceType]
-		if !ok {
-			err := fmt.Errorf("no resource handler registered for resource type %s", att.ResourceType)
+			err = databaseutil.WrapDBError(err, logger, "lock file before delete")
 			span.RecordError(err)
 			return err
 		}
 
-		if err := handler.RemoveFileReference(traceCtx, fileID, att.ResourceID); err != nil {
-			err = fmt.Errorf(
-				"remove file reference from resource type %s resource id %s: %w",
-				att.ResourceType,
-				att.ResourceID.String(),
-				err,
-			)
-			span.RecordError(err)
-			return err
-		}
-
-		err := qtx.DeleteAttachment(traceCtx, att.ID)
+		attachments, err := qtx.ListAttachmentsByFileID(traceCtx, fileID)
 		if err != nil {
-			err = databaseutil.WrapDBError(err, logger, "delete attachment after removing resource reference")
+			err = databaseutil.WrapDBError(err, logger, "list attachments before delete file")
 			span.RecordError(err)
 			return err
 		}
-	}
+		attachmentCount = len(attachments)
 
-	err = qtx.Delete(traceCtx, fileID)
-	if err != nil {
-		err = databaseutil.WrapDBError(err, logger, "delete file row")
-		span.RecordError(err)
-		return err
-	}
+		for _, att := range attachments {
+			handler, ok := s.resourceHandlers[att.ResourceType]
+			if !ok {
+				err := fmt.Errorf("no resource handler registered for resource type %s", att.ResourceType)
+				span.RecordError(err)
+				return err
+			}
 
-	if needCommit {
-		err := tx.Commit(traceCtx)
+			if err := handler.RemoveFileReference(traceCtx, fileID, att.ResourceID); err != nil {
+				err = fmt.Errorf(
+					"remove file reference from resource type %s resource id %s: %w",
+					att.ResourceType,
+					att.ResourceID.String(),
+					err,
+				)
+				span.RecordError(err)
+				return err
+			}
+
+			err := qtx.DeleteAttachment(traceCtx, att.ID)
+			if err != nil {
+				err = databaseutil.WrapDBError(err, logger, "delete attachment after removing resource reference")
+				span.RecordError(err)
+				return err
+			}
+		}
+
+		err = qtx.Delete(traceCtx, fileID)
 		if err != nil {
-			err = databaseutil.WrapDBError(err, logger, "commit tx")
+			err = databaseutil.WrapDBError(err, logger, "delete file row")
 			span.RecordError(err)
 			return err
 		}
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	logger.Info("file deleted successfully through orchestration",
 		zap.String("file_id", fileID.String()),
-		zap.Int("attachment_count", len(attachments)),
+		zap.Int("attachment_count", attachmentCount),
 	)
 
 	return nil

--- a/internal/form/answer/resource_handler.go
+++ b/internal/form/answer/resource_handler.go
@@ -3,6 +3,7 @@ package answer
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"NYCU-SDC/core-system-backend/internal"
 	"NYCU-SDC/core-system-backend/internal/file"
@@ -37,12 +38,15 @@ func NewFileResourceHandler(logger *zap.Logger, queries FileReferenceQuerier) *F
 }
 
 // WithTx returns a handler that reads and writes answer file references on tx.
-func (h *FileResourceHandler) WithTx(tx pgx.Tx) file.ResourceHandler {
+func (h *FileResourceHandler) WithTx(tx pgx.Tx) (file.ResourceHandler, error) {
 	q, ok := h.queries.(*Queries)
 	if !ok {
-		return h
+		return nil, fmt.Errorf(
+			"answer file resource handler requires *answer.Queries for transactional operations, got %T",
+			h.queries,
+		)
 	}
-	return NewFileResourceHandler(h.logger, q.WithTx(tx))
+	return NewFileResourceHandler(h.logger, q.WithTx(tx)), nil
 }
 
 func (h *FileResourceHandler) ResourceType() file.ResourceType {

--- a/internal/form/answer/resource_handler.go
+++ b/internal/form/answer/resource_handler.go
@@ -11,6 +11,7 @@ import (
 	databaseutil "github.com/NYCU-SDC/summer/pkg/database"
 	logutil "github.com/NYCU-SDC/summer/pkg/log"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -33,6 +34,15 @@ func NewFileResourceHandler(logger *zap.Logger, queries FileReferenceQuerier) *F
 		queries: queries,
 		tracer:  otel.Tracer("answer/file_resource_handler"),
 	}
+}
+
+// WithTx returns a handler that reads and writes answer file references on tx.
+func (h *FileResourceHandler) WithTx(tx pgx.Tx) file.ResourceHandler {
+	q, ok := h.queries.(*Queries)
+	if !ok {
+		return h
+	}
+	return NewFileResourceHandler(h.logger, q.WithTx(tx))
 }
 
 func (h *FileResourceHandler) ResourceType() file.ResourceType {

--- a/internal/form/answer/service.go
+++ b/internal/form/answer/service.go
@@ -31,10 +31,6 @@ type Querier interface {
 	WithTx(tx pgx.Tx) *Queries
 }
 
-type TxBeginner interface {
-	BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error)
-}
-
 type QuestionStore interface {
 	ListSectionsWithAnswersByFormID(ctx context.Context, formID uuid.UUID) ([]question.SectionWithAnswerableList, error)
 	GetAnswerableMapByFormID(ctx context.Context, formID uuid.UUID) (map[string]question.Answerable, error)
@@ -90,6 +86,12 @@ func NewService(logger *zap.Logger, db DBTX, questionStore QuestionStore, fileSe
 		questionStore:    questionStore,
 		fileService:      fileService,
 	}
+}
+
+func (s *Service) withFileTransaction(ctx context.Context, fn func(*Queries, FileService) error) error {
+	return internal.WithTransaction(ctx, s.db, s.logger, func(tx pgx.Tx) error {
+		return fn(s.queries.WithTx(tx), s.fileService.WithTx(tx))
+	})
 }
 
 func (s Service) List(ctx context.Context, formID, responseID uuid.UUID) ([]Answer, []question.Answerable, map[string]question.Answerable, error) {
@@ -474,138 +476,113 @@ func (s Service) UploadFiles(ctx context.Context, formID, responseID, questionID
 
 	// Read existing uploaded files from the existing answer (if any) for append.
 	var (
-		tx         pgx.Tx
-		needCommit bool
+		newEntries     []shared.UploadFileEntry
+		upsertedAnswer Answer
+		mergedCount    int
 	)
 
-	tx, needCommit, err = s.beginOrReuseTx(traceCtx)
-	if err != nil {
-		err = databaseutil.WrapDBError(err, logger, "begin tx for upload files")
-		span.RecordError(err)
-		return nil, Answer{}, nil, err
-	}
-
-	if needCommit {
-		defer func() {
-			rollbackErr := tx.Rollback(traceCtx)
-			if rollbackErr == nil {
-				return
-			}
-			if errors.Is(rollbackErr, pgx.ErrTxClosed) {
-				return
-			}
-
-			logger.Error("rollback failed", zap.Error(rollbackErr))
-			span.RecordError(rollbackErr)
-		}()
-	}
-
-	qtx := s.queries.WithTx(tx)
-	ftx := s.fileService.WithTx(tx)
-
-	existingEntries, err := s.loadPreviousUploadFileEntries(traceCtx, qtx, responseID, questionID)
-	if err != nil {
-		logger.Error("failed to load previous upload file entries",
-			zap.String("questionID", questionID.String()),
-			zap.Error(err),
-		)
-		span.RecordError(err)
-		return nil, Answer{}, nil, err
-	}
-
-	// Save each uploaded file; on failure clean up any already-saved new files
-	newEntries := make([]shared.UploadFileEntry, 0, len(files))
-
-	for _, fh := range files {
-		f, err := fh.Open()
+	err = s.withFileTransaction(traceCtx, func(qtx *Queries, ftx FileService) error {
+		existingEntries, err := s.loadPreviousUploadFileEntries(traceCtx, qtx, responseID, questionID)
 		if err != nil {
-			logger.Error("failed to open uploaded file", zap.String("filename", fh.Filename), zap.Error(err))
-			span.RecordError(err)
-			return nil, Answer{}, nil, fmt.Errorf("failed to open uploaded file %q: %w", fh.Filename, internal.ErrFailedToSaveFile)
-		}
-
-		savedFile, saveErr := ftx.SaveFile(traceCtx, f, fh.Filename, fh.Header.Get("Content-Type"), &uploadedBy)
-		closeErr := f.Close()
-		if closeErr != nil {
-			logger.Warn("failed to close uploaded file stream",
-				zap.String("filename", fh.Filename),
-				zap.Error(closeErr),
+			logger.Error("failed to load previous upload file entries",
+				zap.String("questionID", questionID.String()),
+				zap.Error(err),
 			)
+			span.RecordError(err)
+			return err
 		}
 
-		if saveErr != nil {
-			logger.Error("failed to save uploaded file", zap.String("filename", fh.Filename), zap.Error(saveErr))
-			span.RecordError(saveErr)
-			return nil, Answer{}, nil, fmt.Errorf("failed to save file %q: %w", fh.Filename, internal.ErrFailedToSaveFile)
+		entries := make([]shared.UploadFileEntry, 0, len(files))
+
+		for _, fh := range files {
+			f, err := fh.Open()
+			if err != nil {
+				logger.Error("failed to open uploaded file", zap.String("filename", fh.Filename), zap.Error(err))
+				span.RecordError(err)
+				return fmt.Errorf("failed to open uploaded file %q: %w", fh.Filename, internal.ErrFailedToSaveFile)
+			}
+
+			savedFile, saveErr := ftx.SaveFile(traceCtx, f, fh.Filename, fh.Header.Get("Content-Type"), &uploadedBy)
+			closeErr := f.Close()
+			if closeErr != nil {
+				logger.Warn("failed to close uploaded file stream",
+					zap.String("filename", fh.Filename),
+					zap.Error(closeErr),
+				)
+			}
+
+			if saveErr != nil {
+				logger.Error("failed to save uploaded file", zap.String("filename", fh.Filename), zap.Error(saveErr))
+				span.RecordError(saveErr)
+				return fmt.Errorf("failed to save file %q: %w", fh.Filename, internal.ErrFailedToSaveFile)
+			}
+
+			entries = append(entries, shared.UploadFileEntry{
+				FileID:           savedFile.ID,
+				OriginalFilename: savedFile.OriginalFilename,
+				ContentType:      savedFile.ContentType,
+				Size:             savedFile.Size,
+			})
 		}
 
-		newEntries = append(newEntries, shared.UploadFileEntry{
-			FileID:           savedFile.ID,
-			OriginalFilename: savedFile.OriginalFilename,
-			ContentType:      savedFile.ContentType,
-			Size:             savedFile.Size,
-		})
-	}
+		mergedEntries := make([]shared.UploadFileEntry, 0, len(existingEntries)+len(entries))
+		mergedEntries = append(mergedEntries, existingEntries...)
+		mergedEntries = append(mergedEntries, entries...)
 
-	// Append new files to existing files
-	mergedEntries := make([]shared.UploadFileEntry, 0, len(existingEntries)+len(newEntries))
-	mergedEntries = append(mergedEntries, existingEntries...)
-	mergedEntries = append(mergedEntries, newEntries...)
+		answerValue, err := json.Marshal(shared.UploadFileAnswer{Files: mergedEntries})
+		if err != nil {
+			logger.Error("failed to marshal upload file answer value", zap.String("questionID", questionID.String()), zap.Error(err))
+			span.RecordError(err)
+			return fmt.Errorf("failed to marshal upload file answer: %w", internal.ErrValidationFailed)
+		}
 
-	// Build the answer value as a full UploadFileAnswer and upsert
-	answerValue, err := json.Marshal(shared.UploadFileAnswer{Files: mergedEntries})
-	if err != nil {
-		logger.Error("failed to marshal upload file answer value", zap.String("questionID", questionID.String()), zap.Error(err))
-		span.RecordError(err)
-		return nil, Answer{}, nil, fmt.Errorf("failed to marshal upload file answer: %w", internal.ErrValidationFailed)
-	}
-
-	upsertedAnswers, err := qtx.BatchUpsert(
-		traceCtx,
-		BatchUpsertParams{
-			ResponseIds: []uuid.UUID{responseID},
-			QuestionIds: []uuid.UUID{questionID},
-			Values:      [][]byte{answerValue},
-		})
-	if err != nil {
-		err = databaseutil.WrapDBError(err, logger, "batch upsert upload file answer")
-		span.RecordError(err)
-		return nil, Answer{}, nil, fmt.Errorf("failed to upsert upload file answer: %w", err)
-	}
-
-	upsertedAnswer := upsertedAnswers[0]
-
-	for _, entry := range newEntries {
-		_, attachErr := ftx.CreateAttachment(
+		upsertedAnswers, err := qtx.BatchUpsert(
 			traceCtx,
-			entry.FileID,
-			file.ResourceTypeFormAnswer,
-			upsertedAnswer.ID,
-			uploadedBy,
-		)
-		if attachErr != nil {
-			logger.Error("failed to create file attachment after upload answer upsert",
-				zap.String("answerID", upsertedAnswer.ID.String()),
-				zap.String("fileID", entry.FileID.String()),
-				zap.Error(attachErr),
-			)
-			span.RecordError(attachErr)
-			return nil, Answer{}, nil, fmt.Errorf("failed to create attachment for file %s: %w", entry.FileID, attachErr)
-		}
-	}
-
-	if needCommit {
-		if err := tx.Commit(traceCtx); err != nil {
-			err = databaseutil.WrapDBError(err, logger, "commit upload files tx")
+			BatchUpsertParams{
+				ResponseIds: []uuid.UUID{responseID},
+				QuestionIds: []uuid.UUID{questionID},
+				Values:      [][]byte{answerValue},
+			})
+		if err != nil {
+			err = databaseutil.WrapDBError(err, logger, "batch upsert upload file answer")
 			span.RecordError(err)
-			return nil, Answer{}, nil, err
+			return fmt.Errorf("failed to upsert upload file answer: %w", err)
 		}
+
+		answer := upsertedAnswers[0]
+
+		for _, entry := range entries {
+			_, attachErr := ftx.CreateAttachment(
+				traceCtx,
+				entry.FileID,
+				file.ResourceTypeFormAnswer,
+				answer.ID,
+				uploadedBy,
+			)
+			if attachErr != nil {
+				logger.Error("failed to create file attachment after upload answer upsert",
+					zap.String("answerID", answer.ID.String()),
+					zap.String("fileID", entry.FileID.String()),
+					zap.Error(attachErr),
+				)
+				span.RecordError(attachErr)
+				return fmt.Errorf("failed to create attachment for file %s: %w", entry.FileID, attachErr)
+			}
+		}
+
+		newEntries = entries
+		upsertedAnswer = answer
+		mergedCount = len(mergedEntries)
+		return nil
+	})
+	if err != nil {
+		return nil, Answer{}, nil, err
 	}
 
 	logger.Info("successfully uploaded files and upserted answer",
 		zap.String("questionID", questionID.String()),
 		zap.String("answerID", upsertedAnswer.ID.String()),
-		zap.Int("fileCount", len(mergedEntries)),
+		zap.Int("fileCount", mergedCount),
 	)
 
 	return newEntries, upsertedAnswer, answerable, nil
@@ -634,26 +611,6 @@ func (s Service) loadPreviousUploadFileEntries(ctx context.Context, q Querier, r
 	}
 
 	return existingUploadAnswer.Files, nil
-}
-
-func (s Service) beginOrReuseTx(
-	ctx context.Context,
-) (pgx.Tx, bool, error) {
-	if existingTx, ok := s.db.(pgx.Tx); ok {
-		return existingTx, false, nil
-	}
-
-	beginner, ok := s.db.(TxBeginner)
-	if !ok {
-		return nil, false, fmt.Errorf("db does not support transactions")
-	}
-
-	tx, err := beginner.BeginTx(ctx, pgx.TxOptions{})
-	if err != nil {
-		return nil, false, err
-	}
-
-	return tx, true, nil
 }
 
 // MergeAnswersForWorkflowResolution returns a new slice: a shallow copy of currentAnswers

--- a/internal/form/question/date.go
+++ b/internal/form/question/date.go
@@ -2,7 +2,6 @@ package question
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -338,7 +337,16 @@ func (d Date) DisplayValue(rawValue json.RawMessage) (string, error) {
 }
 
 func (d Date) MatchesPattern(rawValue json.RawMessage, pattern string) (bool, error) {
-	return false, errors.New("MatchesPattern is not supported for date question type")
+	display, err := d.DisplayValue(rawValue)
+	if err != nil {
+		return false, err
+	}
+
+	match, err := matchPattern(display, pattern)
+	if err != nil {
+		return false, fmt.Errorf("failed to match pattern for date answer: %w", err)
+	}
+	return match, nil
 }
 
 // GenerateDateMetadata creates and validates metadata JSON for date questions

--- a/internal/form/question/file.go
+++ b/internal/form/question/file.go
@@ -220,7 +220,16 @@ func (u UploadFile) DisplayValue(rawValue json.RawMessage) (string, error) {
 }
 
 func (u UploadFile) MatchesPattern(rawValue json.RawMessage, pattern string) (bool, error) {
-	return false, errors.New("MatchesPattern is not supported for upload_file question type")
+	display, err := u.DisplayValue(rawValue)
+	if err != nil {
+		return false, err
+	}
+
+	match, err := matchPattern(display, pattern)
+	if err != nil {
+		return false, fmt.Errorf("failed to match pattern for upload file answer: %w", err)
+	}
+	return match, nil
 }
 
 // GenerateUploadFileMetadata generates metadata for upload file question

--- a/internal/form/question/oauth.go
+++ b/internal/form/question/oauth.go
@@ -121,7 +121,16 @@ func (o OAuthConnect) DisplayValue(rawValue json.RawMessage) (string, error) {
 }
 
 func (o OAuthConnect) MatchesPattern(rawValue json.RawMessage, pattern string) (bool, error) {
-	return false, errors.New("MatchesPattern is not supported for oauth_connect question type")
+	display, err := o.DisplayValue(rawValue)
+	if err != nil {
+		return false, err
+	}
+
+	match, err := matchPattern(display, pattern)
+	if err != nil {
+		return false, fmt.Errorf("failed to match pattern for oauth_connect answer: %w", err)
+	}
+	return match, nil
 }
 
 func GenerateOauthConnectMetadata(provider string) ([]byte, error) {

--- a/internal/form/question/text.go
+++ b/internal/form/question/text.go
@@ -93,17 +93,12 @@ func (s ShortText) DisplayValue(rawValue json.RawMessage) (string, error) {
 }
 
 func (s ShortText) MatchesPattern(rawValue json.RawMessage, pattern string) (bool, error) {
-	answer, err := s.DecodeStorage(rawValue)
+	display, err := s.DisplayValue(rawValue)
 	if err != nil {
-		return false, fmt.Errorf("failed to decode short text answer: %w", err)
+		return false, err
 	}
 
-	shortTextAnswer, ok := answer.(shared.ShortTextAnswer)
-	if !ok {
-		return false, fmt.Errorf("expected shared.ShortTextAnswer, got %T", answer)
-	}
-
-	match, err := matchPattern(shortTextAnswer.Value, pattern)
+	match, err := matchPattern(display, pattern)
 	if err != nil {
 		return false, fmt.Errorf("failed to match pattern for short text answer: %w", err)
 	}
@@ -300,17 +295,12 @@ func (h Hyperlink) DisplayValue(rawValue json.RawMessage) (string, error) {
 }
 
 func (h Hyperlink) MatchesPattern(rawValue json.RawMessage, pattern string) (bool, error) {
-	answer, err := h.DecodeStorage(rawValue)
+	display, err := h.DisplayValue(rawValue)
 	if err != nil {
-		return false, fmt.Errorf("failed to decode hyperlink answer: %w", err)
+		return false, err
 	}
 
-	hyperlinkAnswer, ok := answer.(shared.HyperlinkAnswer)
-	if !ok {
-		return false, fmt.Errorf("expected shared.HyperlinkAnswer, got %T", answer)
-	}
-
-	match, err := matchPattern(hyperlinkAnswer.Value, pattern)
+	match, err := matchPattern(display, pattern)
 	if err != nil {
 		return false, fmt.Errorf("failed to match pattern for hyperlink answer: %w", err)
 	}

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -24,6 +24,11 @@ type DBTX interface {
 	QueryRow(context.Context, string, ...interface{}) pgx.Row
 }
 
+// TxBeginner can start a new database transaction (e.g. *pgxpool.Pool).
+type TxBeginner interface {
+	BeginTx(ctx context.Context, opts pgx.TxOptions) (pgx.Tx, error)
+}
+
 func ParseUUID(value string) (uuid.UUID, error) {
 	parsedUUID, err := uuid.Parse(value)
 	if err != nil {

--- a/internal/tx.go
+++ b/internal/tx.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	databaseutil "github.com/NYCU-SDC/summer/pkg/database"
+	"github.com/jackc/pgx/v5"
+	"go.uber.org/zap"
+)
+
+// WithTransaction runs fn inside a pgx transaction. If db is already a pgx.Tx, fn
+// runs on that transaction without begin/commit/rollback. Otherwise db must
+// implement TxBeginner.
+func WithTransaction(
+	ctx context.Context, db DBTX, logger *zap.Logger,
+	fn func(pgx.Tx) error,
+) error {
+	logger = WithContext(ctx, logger)
+
+	existingTx, ok := db.(pgx.Tx)
+	if ok {
+		return fn(existingTx)
+	}
+
+	beginner, ok := db.(TxBeginner)
+	if !ok {
+		return fmt.Errorf("%w", ErrDBTransactionNotSupported)
+	}
+
+	tx, err := beginner.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return databaseutil.WrapDBError(err, logger, "begin tx")
+	}
+
+	defer func() {
+		rollbackErr := tx.Rollback(ctx)
+		if rollbackErr != nil && !errors.Is(rollbackErr, pgx.ErrTxClosed) {
+			logger.Error("rollback failed", zap.Error(rollbackErr))
+		}
+	}()
+
+	err = fn(tx)
+	if err != nil {
+		return err
+	}
+
+	err = tx.Commit(ctx)
+	if err != nil {
+		return databaseutil.WrapDBError(err, logger, "commit tx")
+	}
+
+	return nil
+}

--- a/internal/tx_test.go
+++ b/internal/tx_test.go
@@ -1,0 +1,311 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	databaseutil "github.com/NYCU-SDC/summer/pkg/database"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"go.uber.org/zap"
+)
+
+// stubDB implements DBTX but not TxBeginner, used to test unsupported-db handling.
+type stubDB struct{}
+
+func (stubDB) Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (stubDB) Query(context.Context, string, ...interface{}) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (stubDB) QueryRow(context.Context, string, ...interface{}) pgx.Row {
+	return nil
+}
+
+// trackTx is a pgx.Tx test double that records lifecycle calls and can inject errors.
+type trackTx struct {
+	commitErr   error
+	rollbackErr error
+	committed   bool
+	rolledBack  bool
+}
+
+func (t *trackTx) Begin(context.Context) (pgx.Tx, error) {
+	return t, nil
+}
+
+// Commit marks the tx as committed and returns commitErr when set.
+func (t *trackTx) Commit(context.Context) error {
+	t.committed = true
+	return t.commitErr
+}
+
+// Rollback marks the tx as rolled back and returns rollbackErr when set.
+func (t *trackTx) Rollback(context.Context) error {
+	t.rolledBack = true
+	return t.rollbackErr
+}
+
+func (t *trackTx) CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error) {
+	return 0, nil
+}
+
+func (t *trackTx) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults {
+	return nil
+}
+
+func (t *trackTx) LargeObjects() pgx.LargeObjects {
+	return pgx.LargeObjects{}
+}
+
+func (t *trackTx) Prepare(context.Context, string, string) (*pgconn.StatementDescription, error) {
+	return nil, nil
+}
+
+func (t *trackTx) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (t *trackTx) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (t *trackTx) QueryRow(context.Context, string, ...any) pgx.Row { return nil }
+
+func (t *trackTx) Conn() *pgx.Conn { return nil }
+
+// mockBeginner implements TxBeginner and returns a configured trackTx from BeginTx.
+type mockBeginner struct {
+	tx        *trackTx
+	beginErr  error
+	beginCall int
+}
+
+func (m *mockBeginner) Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (m *mockBeginner) Query(context.Context, string, ...interface{}) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (m *mockBeginner) QueryRow(context.Context, string, ...interface{}) pgx.Row {
+	return nil
+}
+
+// BeginTx increments beginCall and returns tx or beginErr.
+func (m *mockBeginner) BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error) {
+	m.beginCall++
+	if m.beginErr != nil {
+		return nil, m.beginErr
+	}
+
+	return m.tx, nil
+}
+
+// withTransactionFixture holds inputs and observable state for one subtest.
+type withTransactionFixture struct {
+	db       DBTX               // argument to WithTransaction
+	fn       func(pgx.Tx) error // callback under test
+	tx       *trackTx           // set when commit/rollback should be observed
+	beginner *mockBeginner      // set when BeginTx behavior should be observed
+}
+
+func TestWithTransaction(t *testing.T) {
+	t.Parallel()
+
+	callbackErr := errors.New("callback failed")
+	beginErr := errors.New("begin failed")
+	commitErr := errors.New("commit failed")
+
+	// --- Test cases ---
+	testCases := []struct {
+		name     string
+		setup    func(t *testing.T) withTransactionFixture
+		validate func(t *testing.T, err error, f withTransactionFixture)
+	}{
+		{
+			name: "reuses existing tx",
+			setup: func(t *testing.T) withTransactionFixture {
+				tx := &trackTx{}
+				return withTransactionFixture{
+					db: tx,
+					fn: func(got pgx.Tx) error {
+						if got != tx {
+							t.Fatal("expected same tx instance")
+						}
+						return nil
+					},
+					tx: tx,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if f.tx.committed || f.tx.rolledBack {
+					t.Fatal("reused tx must not be committed or rolled back by helper")
+				}
+			},
+		},
+		{
+			name: "commits new tx",
+			setup: func(t *testing.T) withTransactionFixture {
+				tx := &trackTx{rollbackErr: pgx.ErrTxClosed}
+				beginner := &mockBeginner{tx: tx}
+				return withTransactionFixture{
+					db:       beginner,
+					fn:       func(pgx.Tx) error { return nil },
+					tx:       tx,
+					beginner: beginner,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if f.beginner.beginCall != 1 {
+					t.Fatalf("BeginTx calls = %d, want 1", f.beginner.beginCall)
+				}
+				if !f.tx.committed {
+					t.Fatal("Commit not called")
+				}
+			},
+		},
+		{
+			name: "returns callback error",
+			setup: func(t *testing.T) withTransactionFixture {
+				tx := &trackTx{}
+				beginner := &mockBeginner{tx: tx}
+				return withTransactionFixture{
+					db:       beginner,
+					fn:       func(pgx.Tx) error { return callbackErr },
+					tx:       tx,
+					beginner: beginner,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if !errors.Is(err, callbackErr) {
+					t.Fatalf("got %v, want %v", err, callbackErr)
+				}
+				if f.tx.committed {
+					t.Fatal("Commit should not run when callback fails")
+				}
+				if !f.tx.rolledBack {
+					t.Fatal("Rollback not called")
+				}
+			},
+		},
+		{
+			name: "returns callback error when rollback also fails",
+			setup: func(t *testing.T) withTransactionFixture {
+				rollbackErr := errors.New("rollback exploded")
+				tx := &trackTx{rollbackErr: rollbackErr}
+				beginner := &mockBeginner{tx: tx}
+				return withTransactionFixture{
+					db:       beginner,
+					fn:       func(pgx.Tx) error { return callbackErr },
+					tx:       tx,
+					beginner: beginner,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if !errors.Is(err, callbackErr) {
+					t.Fatalf("got %v, want callback error %v", err, callbackErr)
+				}
+				if f.tx.committed {
+					t.Fatal("Commit should not run when callback fails")
+				}
+				if !f.tx.rolledBack {
+					t.Fatal("Rollback not called")
+				}
+			},
+		},
+		{
+			name: "reuses existing tx callback error",
+			setup: func(t *testing.T) withTransactionFixture {
+				tx := &trackTx{}
+				return withTransactionFixture{
+					db: tx,
+					fn: func(pgx.Tx) error { return callbackErr },
+					tx: tx,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if !errors.Is(err, callbackErr) {
+					t.Fatalf("got %v, want %v", err, callbackErr)
+				}
+				if f.tx.committed || f.tx.rolledBack {
+					t.Fatal("reused tx must not be committed or rolled back by helper")
+				}
+			},
+		},
+		{
+			name: "unsupported db",
+			setup: func(t *testing.T) withTransactionFixture {
+				return withTransactionFixture{
+					db: stubDB{},
+					fn: func(pgx.Tx) error { return nil },
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				if !errors.Is(err, ErrDBTransactionNotSupported) {
+					t.Fatalf("got %v, want %v", err, ErrDBTransactionNotSupported)
+				}
+			},
+		},
+		{
+			name: "wraps begin failure",
+			setup: func(t *testing.T) withTransactionFixture {
+				beginner := &mockBeginner{beginErr: beginErr}
+				return withTransactionFixture{
+					db:       beginner,
+					fn:       func(pgx.Tx) error { return nil },
+					beginner: beginner,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				var wrapped databaseutil.InternalServerError
+				if !errors.As(err, &wrapped) {
+					t.Fatalf("expected wrapped db error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "wraps commit failure",
+			setup: func(t *testing.T) withTransactionFixture {
+				tx := &trackTx{commitErr: commitErr, rollbackErr: pgx.ErrTxClosed}
+				beginner := &mockBeginner{tx: tx}
+				return withTransactionFixture{
+					db:       beginner,
+					fn:       func(pgx.Tx) error { return nil },
+					tx:       tx,
+					beginner: beginner,
+				}
+			},
+			validate: func(t *testing.T, err error, f withTransactionFixture) {
+				var wrapped databaseutil.InternalServerError
+				if !errors.As(err, &wrapped) {
+					t.Fatalf("expected wrapped db error, got %v", err)
+				}
+				if !f.tx.committed {
+					t.Fatal("Commit should have been attempted")
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := tc.setup(t)
+			err := WithTransaction(context.Background(), fixture.db, zap.NewNop(), fixture.fn)
+			tc.validate(t, err, fixture)
+		})
+	}
+}

--- a/internal/unit/service.go
+++ b/internal/unit/service.go
@@ -46,10 +46,6 @@ type Querier interface {
 	WithTx(tx pgx.Tx) *Queries
 }
 
-type TxBeginner interface {
-	BeginTx(ctx context.Context, opts pgx.TxOptions) (pgx.Tx, error)
-}
-
 type Service struct {
 	db          DBTX
 	logger      *zap.Logger
@@ -94,6 +90,12 @@ func NewService(logger *zap.Logger, db DBTX, tenantStore tenantStore) *Service {
 		tracer:      otel.Tracer("unit/service"),
 		tenantStore: tenantStore,
 	}
+}
+
+func (s *Service) withTransaction(ctx context.Context, fn func(*Queries) error) error {
+	return internal.WithTransaction(ctx, s.db, s.logger, func(tx pgx.Tx) error {
+		return fn(s.queries.WithTx(tx))
+	})
 }
 
 func (s *Service) CreateOrganizationWithUserID(ctx context.Context, name string, description string, slug string, userID uuid.UUID, metadata []byte) (Unit, error) {
@@ -574,106 +576,64 @@ func (s *Service) UpdateUnitMemberRole(
 
 	logger := logutil.WithContext(traceCtx, s.logger)
 
-	var (
-		tx         pgx.Tx
-		err        error
-		needCommit bool
-	)
-
-	existingTx, ok := s.db.(pgx.Tx)
-	if ok {
-		// reuse
-		tx = existingTx
-	} else {
-		// build tx
-		beginner, ok := s.db.(TxBeginner)
-		if !ok {
-			return fmt.Errorf("db does not support transactions")
-		}
-
-		tx, err = beginner.BeginTx(traceCtx, pgx.TxOptions{})
+	return s.withTransaction(traceCtx, func(qtx *Queries) error {
+		// lock admins
+		_, err := qtx.LockAdminsForUnit(traceCtx, unitID)
 		if err != nil {
-			err = databaseutil.WrapDBError(err, logger, "begin tx")
+			err = databaseutil.WrapDBError(err, logger, "lock admin rows")
 			span.RecordError(err)
 			return err
 		}
 
-		needCommit = true
-
-		defer func() {
-			err := tx.Rollback(traceCtx)
-			if err != nil &&
-				!errors.Is(err, pgx.ErrTxClosed) {
-				logger.Error("rollback failed", zap.Error(err))
-			}
-		}()
-	}
-
-	qtx := s.queries.WithTx(tx)
-
-	// lock admins
-	_, err = qtx.LockAdminsForUnit(traceCtx, unitID)
-	if err != nil {
-		err = databaseutil.WrapDBError(err, logger, "lock admin rows")
-		span.RecordError(err)
-		return err
-	}
-
-	currentRole, err := qtx.GetMemberRole(traceCtx, GetMemberRoleParams{
-		UnitID:   unitID,
-		MemberID: memberID,
-	})
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			span.RecordError(internal.ErrNotFound)
-			return internal.ErrNotFound
-		}
-		err = databaseutil.WrapDBError(err, logger, "get member role")
-		span.RecordError(err)
-		return err
-	}
-
-	if currentRole == newRole {
-		if needCommit {
-			return tx.Commit(traceCtx)
-		}
-		return nil
-	}
-
-	if currentRole == UnitRoleAdmin && newRole != UnitRoleAdmin {
-		count, err := qtx.CountMembersByRole(traceCtx, CountMembersByRoleParams{
-			UnitID: unitID,
-			Role:   UnitRoleAdmin,
+		currentRole, err := qtx.GetMemberRole(traceCtx, GetMemberRoleParams{
+			UnitID:   unitID,
+			MemberID: memberID,
 		})
 		if err != nil {
-			err = databaseutil.WrapDBError(err, logger, "count admin")
+			if errors.Is(err, pgx.ErrNoRows) {
+				span.RecordError(internal.ErrNotFound)
+				return internal.ErrNotFound
+			}
+			err = databaseutil.WrapDBError(err, logger, "get member role")
 			span.RecordError(err)
 			return err
 		}
 
-		if count <= 1 {
-			logger.Error("cannot remove last admin")
-			span.RecordError(internal.ErrCannotRemoveLastAdmin)
-			return internal.ErrCannotRemoveLastAdmin
+		if currentRole == newRole {
+			return nil
 		}
-	}
 
-	err = qtx.UpdateMemberRole(traceCtx, UpdateMemberRoleParams{
-		UnitID:   unitID,
-		MemberID: memberID,
-		Role:     newRole,
+		if currentRole == UnitRoleAdmin && newRole != UnitRoleAdmin {
+			count, err := qtx.CountMembersByRole(traceCtx, CountMembersByRoleParams{
+				UnitID: unitID,
+				Role:   UnitRoleAdmin,
+			})
+			if err != nil {
+				err = databaseutil.WrapDBError(err, logger, "count admin")
+				span.RecordError(err)
+				return err
+			}
+
+			if count <= 1 {
+				logger.Error("cannot remove last admin")
+				span.RecordError(internal.ErrCannotRemoveLastAdmin)
+				return internal.ErrCannotRemoveLastAdmin
+			}
+		}
+
+		err = qtx.UpdateMemberRole(traceCtx, UpdateMemberRoleParams{
+			UnitID:   unitID,
+			MemberID: memberID,
+			Role:     newRole,
+		})
+		if err != nil {
+			err = databaseutil.WrapDBError(err, logger, "update member role")
+			span.RecordError(err)
+			return err
+		}
+
+		return nil
 	})
-	if err != nil {
-		err = databaseutil.WrapDBError(err, logger, "update member role")
-		span.RecordError(err)
-		return err
-	}
-
-	if needCommit {
-		return tx.Commit(traceCtx)
-	}
-
-	return nil
 }
 
 func (s *Service) SlugExists(ctx context.Context, slug string) (bool, error) {


### PR DESCRIPTION
## Type of changes
- Refactor

## Purpose
- Add shared `internal.WithTransaction` helper for consistent begin/commit/rollback semantics across services
- Migrate `file`, `form/answer`, and `unit` services off duplicated inline transaction boilerplate

## Additional Information

[Study and Implement Note](https://www.notion.so/sdc-nycu/CORE-360-Transaction-Centralization-36a7dadd804080a694dcef5373424626?source=copy_link)
