### PR TITLE
[CORE-368] Fix Tenant Middleware and Org DELETE Authentication

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -307,7 +307,7 @@ func main() {
 	mux.Handle("GET /api/orgs/{slug}", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleMember, slugResolver)).HandlerFunc(unitHandler.GetOrgByID))
 	mux.Handle("POST /api/orgs", authMiddleware.Append(globalAdmin).HandlerFunc(unitHandler.CreateOrg))
 	mux.Handle("PUT /api/orgs/{slug}", tenantAuthMiddleware.Append(unitRole.Require(auth.RoleAdmin, slugResolver)).HandlerFunc(unitHandler.UpdateOrg))
-	mux.Handle("DELETE /api/orgs/{slug}", authMiddleware.Append(globalAdmin).HandlerFunc(unitHandler.DeleteOrg))
+	mux.Handle("DELETE /api/orgs/{slug}", tenantAuthMiddleware.Append(globalAdmin).HandlerFunc(unitHandler.DeleteOrg))
 
 	// Organization Relations
 	// ----------------------

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -215,7 +215,7 @@ func main() {
 	traceMiddleware := trace.NewMiddleware(logger, cfg.Debug)
 	corsMiddleware := cors.NewMiddleware(logger, cfg.AllowOrigins)
 	jwtMiddleware := jwt.NewMiddleware(logger, validator, problemWriter, jwtService)
-	tenantMiddleware := tenant.NewMiddleware(logger, dbPool, tenantService)
+	tenantMiddleware := tenant.NewMiddleware(logger, dbPool, problemWriter, tenantService)
 	formMiddleware := form.NewMiddleware(logger, formService, problemWriter)
 
 	// Basic Middleware (Tracing and Recovery)

--- a/internal/tenant/middleware.go
+++ b/internal/tenant/middleware.go
@@ -20,24 +20,25 @@ type reader interface {
 }
 
 type Middleware struct {
-	tracer       trace.Tracer
-	logger       *zap.Logger
-	masterDBPool *pgxpool.Pool
-
-	reader reader
+	tracer        trace.Tracer
+	logger        *zap.Logger
+	masterDBPool  *pgxpool.Pool
+	problemWriter *problem.HttpWriter
+	reader        reader
 }
 
 func NewMiddleware(
 	logger *zap.Logger,
 	masterDBPool *pgxpool.Pool,
-
+	problemWriter *problem.HttpWriter,
 	reader reader,
 ) *Middleware {
 	return &Middleware{
-		tracer:       otel.Tracer("tenant/middleware"),
-		logger:       logger,
-		reader:       reader,
-		masterDBPool: masterDBPool,
+		tracer:        otel.Tracer("tenant/middleware"),
+		logger:        logger,
+		reader:        reader,
+		masterDBPool:  masterDBPool,
+		problemWriter: problemWriter,
 	}
 }
 
@@ -50,25 +51,25 @@ func (m *Middleware) Middleware(next http.HandlerFunc) http.HandlerFunc {
 		slug := r.PathValue("slug")
 		if slug == "" {
 			logger.Error("User slug is empty", zap.String("path", r.URL.Path))
-			problem.New().WriteError(traceCtx, w, handlerutil.ErrInternalServer, logger)
+			m.problemWriter.WriteError(traceCtx, w, handlerutil.ErrInternalServer, logger)
 			return
 		}
 
 		exists, orgID, err := m.reader.GetSlugStatus(traceCtx, slug)
 		if err != nil {
 			span.RecordError(err)
-			problem.New().WriteError(traceCtx, w, err, logger)
+			m.problemWriter.WriteError(traceCtx, w, err, logger)
 			return
 		}
 		if !exists {
-			problem.New().WriteError(traceCtx, w, internal.ErrOrgSlugNotFound, logger)
+			m.problemWriter.WriteError(traceCtx, w, internal.ErrOrgSlugNotFound, logger)
 			return
 		}
 
 		tenant, err := m.reader.Get(traceCtx, orgID)
 		if err != nil {
 			span.RecordError(err)
-			problem.New().WriteError(traceCtx, w, err, logger)
+			m.problemWriter.WriteError(traceCtx, w, err, logger)
 			return
 		}
 
@@ -77,7 +78,7 @@ func (m *Middleware) Middleware(next http.HandlerFunc) http.HandlerFunc {
 			conn = m.masterDBPool
 		} else {
 			logger.Error("unsupported tenant database strategy", zap.String("strategy", string(tenant.DbStrategy)))
-			problem.New().WriteError(traceCtx, w, handlerutil.ErrInternalServer, logger)
+			m.problemWriter.WriteError(traceCtx, w, handlerutil.ErrInternalServer, logger)
 			return
 		}
 

--- a/internal/tenant/middleware.go
+++ b/internal/tenant/middleware.go
@@ -54,10 +54,14 @@ func (m *Middleware) Middleware(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		_, orgID, err := m.reader.GetSlugStatus(traceCtx, slug)
+		exists, orgID, err := m.reader.GetSlugStatus(traceCtx, slug)
 		if err != nil {
 			span.RecordError(err)
 			problem.New().WriteError(traceCtx, w, err, logger)
+			return
+		}
+		if !exists {
+			problem.New().WriteError(traceCtx, w, internal.ErrOrgSlugNotFound, logger)
 			return
 		}
 


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Route `DELETE /api/orgs/{slug}` through tenant authentication middleware
- Return not-found when organization slug does not exist in tenant middleware
- Use shared problem writer for consistent tenant middleware error responses
- Resolve issue CORE-368

## Additional Information

- Jira: https://clustron.atlassian.net/browse/CORE-368