### PR TITLE
[CORE-369] Fix ListResponse Total, Draft, and Submitted Counts

### DIFF
--- a/internal/form/response/handler.go
+++ b/internal/form/response/handler.go
@@ -41,8 +41,11 @@ type Response struct {
 }
 
 type ListResponse struct {
-	FormID        string     `json:"formId" validate:"required,uuid"`
-	ResponseJSONs []Response `json:"responses" validate:"required,dive"`
+	FormID         string     `json:"formId" validate:"required,uuid"`
+	TotalCount     int32      `json:"totalCount" validate:"required"`
+	DraftCount     int32      `json:"draftCount" validate:"required"`
+	SubmittedCount int32      `json:"submittedCount" validate:"required"`
+	ResponseJSONs  []Response `json:"responses" validate:"required,dive"`
 }
 
 type GetFormResponse struct {
@@ -158,11 +161,23 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	listResponse := buildListResponse(formID, allResponses)
+
+	handlerutil.WriteJSONResponse(w, http.StatusOK, listResponse)
+}
+
+func buildListResponse(formID uuid.UUID, responses []FormResponse) ListResponse {
 	listResponse := ListResponse{
 		FormID:        formID.String(),
-		ResponseJSONs: make([]Response, 0, len(allResponses)),
+		TotalCount:    int32(len(responses)),
+		ResponseJSONs: make([]Response, 0, len(responses)),
 	}
-	for _, currentResponse := range allResponses {
+	for _, currentResponse := range responses {
+		if currentResponse.Progress == ResponseProgressSubmitted {
+			listResponse.SubmittedCount++
+		} else {
+			listResponse.DraftCount++
+		}
 		listResponse.ResponseJSONs = append(listResponse.ResponseJSONs, Response{
 			ID:          currentResponse.ID.String(),
 			SubmittedBy: currentResponse.SubmittedBy.String(),
@@ -170,8 +185,7 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 			UpdatedAt:   currentResponse.UpdatedAt.Time,
 		})
 	}
-
-	handlerutil.WriteJSONResponse(w, http.StatusOK, listResponse)
+	return listResponse
 }
 
 // ListMe lists responses for a form submitted by the current user
@@ -201,18 +215,7 @@ func (h *Handler) ListMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	listResponse := ListResponse{
-		FormID:        formID.String(),
-		ResponseJSONs: make([]Response, 0),
-	}
-	for _, currentResponse := range userResponses {
-		listResponse.ResponseJSONs = append(listResponse.ResponseJSONs, Response{
-			ID:          currentResponse.ID.String(),
-			SubmittedBy: currentResponse.SubmittedBy.String(),
-			CreatedAt:   currentResponse.CreatedAt.Time,
-			UpdatedAt:   currentResponse.UpdatedAt.Time,
-		})
-	}
+	listResponse := buildListResponse(formID, userResponses)
 
 	handlerutil.WriteJSONResponse(w, http.StatusOK, listResponse)
 }


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
- Expose `total`, `draft`, and `submitted` counts in form response list API payload
- Resolve issue CORE-369

## Additional Information

- Jira: https://clustron.atlassian.net/browse/CORE-369