### PR TITLE
[CORE-370] Add Cancel Submission Endpoint for Responses

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -396,6 +396,7 @@ func main() {
 
 	// Response Operations
 	mux.Handle("POST /api/responses/{responseId}/submit", authMiddleware.Append(availableByResponse).HandlerFunc(submitHandler.SubmitHandler))
+	mux.Handle("POST /api/responses/{responseId}/cancel", authMiddleware.Append(availableByResponse).HandlerFunc(responseHandler.Cancel))
 
 	// Answer Management
 	// ----------------------

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -132,6 +132,7 @@ var (
 	ErrResponseFormIDMismatch = errors.New("response form ID does not match the expected form ID")
 	ErrResponseNotOwned       = errors.New("response does not belong to the current user")
 	ErrResponseEditNotAllowed = errors.New("response is not allowed to be edited")
+	ErrResponseNotSubmitted   = errors.New("response is not submitted")
 
 	// Answer / Workflow: cannot answer questions in a section skipped by workflow
 	ErrAnswerSectionSkipped = errors.New("cannot answer questions in a section that is skipped by the form workflow")
@@ -360,6 +361,8 @@ func ErrorHandler(err error) problem.Problem {
 		return problem.NewForbiddenProblem("response does not belong to the current user")
 	case errors.Is(err, ErrResponseEditNotAllowed):
 		return problem.NewForbiddenProblem("response is not allowed to be edited")
+	case errors.Is(err, ErrResponseNotSubmitted):
+		return problem.NewBadRequestProblem("response is not submitted")
 
 	// Submit Errors
 	case errors.Is(err, ErrResponseNotComplete{}):

--- a/internal/form/response/handler.go
+++ b/internal/form/response/handler.go
@@ -115,6 +115,7 @@ type Store interface {
 	Delete(ctx context.Context, responseID uuid.UUID) error
 	ExportPreview(ctx context.Context, formID uuid.UUID, questionIDs []uuid.UUID) (ExportPreviewResponse, error)
 	ExportDownload(ctx context.Context, formID uuid.UUID, questionIDs []uuid.UUID) ([]byte, string, error)
+	CancelSubmission(ctx context.Context, id uuid.UUID, userID uuid.UUID) error
 }
 
 type QuestionStore interface {
@@ -428,6 +429,34 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	handlerutil.WriteJSONResponse(w, http.StatusCreated, CreateResponse{
 		ID: newResponse.ID.String(),
 	})
+}
+
+// Cancel reverts a submitted response back to draft.
+func (h *Handler) Cancel(w http.ResponseWriter, r *http.Request) {
+	traceCtx, span := h.tracer.Start(r.Context(), "Cancel")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, h.logger)
+
+	responseIDStr := r.PathValue("responseId")
+	responseID, err := handlerutil.ParseUUID(responseIDStr)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	currentUser, ok := user.GetFromContext(traceCtx)
+	if !ok {
+		h.problemWriter.WriteError(traceCtx, w, internal.ErrNoUserInContext, logger)
+		return
+	}
+
+	err = h.store.CancelSubmission(traceCtx, responseID, currentUser.ID)
+	if err != nil {
+		h.problemWriter.WriteError(traceCtx, w, err, logger)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 func (h *Handler) ExportPreview(w http.ResponseWriter, r *http.Request) {

--- a/internal/form/response/queries.sql
+++ b/internal/form/response/queries.sql
@@ -37,6 +37,12 @@ SET submitted_at = now(), progress = 'submitted'
 WHERE id = $1
 RETURNING *;
 
+-- name: RevertSubmission :one
+UPDATE form_responses
+SET submitted_at = NULL, progress = 'draft', updated_at = now()
+WHERE id = $1
+RETURNING *;
+
 -- name: Delete :exec
 DELETE FROM form_responses
 WHERE id = $1;

--- a/internal/form/response/queries.sql.go
+++ b/internal/form/response/queries.sql.go
@@ -274,6 +274,28 @@ func (q *Queries) ListSubmittedByFormID(ctx context.Context, formID uuid.UUID) (
 	return items, nil
 }
 
+const revertSubmission = `-- name: RevertSubmission :one
+UPDATE form_responses
+SET submitted_at = NULL, progress = 'draft', updated_at = now()
+WHERE id = $1
+RETURNING id, form_id, submitted_by, submitted_at, progress, created_at, updated_at
+`
+
+func (q *Queries) RevertSubmission(ctx context.Context, id uuid.UUID) (FormResponse, error) {
+	row := q.db.QueryRow(ctx, revertSubmission, id)
+	var i FormResponse
+	err := row.Scan(
+		&i.ID,
+		&i.FormID,
+		&i.SubmittedBy,
+		&i.SubmittedAt,
+		&i.Progress,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const update = `-- name: Update :exec
 UPDATE form_responses
 SET updated_at = now(), progress = $2

--- a/internal/form/response/service.go
+++ b/internal/form/response/service.go
@@ -35,6 +35,7 @@ type Querier interface {
 	ListByFormIDAndSubmittedBy(ctx context.Context, arg ListByFormIDAndSubmittedByParams) ([]FormResponse, error)
 	ListBySubmittedBy(ctx context.Context, userID uuid.UUID) ([]FormResponse, error)
 	UpdateSubmitted(ctx context.Context, id uuid.UUID) (FormResponse, error)
+	RevertSubmission(ctx context.Context, id uuid.UUID) (FormResponse, error)
 	ListSubmittedByFormID(ctx context.Context, formID uuid.UUID) ([]FormResponse, error)
 	GetEditInfo(ctx context.Context, id uuid.UUID) (GetEditInfoRow, error)
 }
@@ -761,6 +762,32 @@ func (s Service) UpdateSubmitted(ctx context.Context, id uuid.UUID) (FormRespons
 	}
 
 	return formResponse, nil
+}
+
+func (s Service) CancelSubmission(ctx context.Context, id uuid.UUID, userID uuid.UUID) error {
+	traceCtx, span := s.tracer.Start(ctx, "CancelSubmission")
+	defer span.End()
+	logger := logutil.WithContext(traceCtx, s.logger)
+
+	formResponse, err := s.GetByID(traceCtx, id)
+	if err != nil {
+		return err
+	}
+	if formResponse.SubmittedBy != userID {
+		return internal.ErrResponseNotOwned
+	}
+	if formResponse.Progress != ResponseProgressSubmitted {
+		return internal.ErrResponseNotSubmitted
+	}
+
+	_, err = s.queries.RevertSubmission(traceCtx, id)
+	if err != nil {
+		err = databaseutil.WrapDBErrorWithKeyValue(err, "response", "id", id.String(), logger, "revert response submission")
+		span.RecordError(err)
+		return err
+	}
+
+	return nil
 }
 
 // ResolveWorkflowSectionsForResponse runs ResolveSections and builds sectionActiveMap when a workflow exists.

--- a/test/integration/form/form_test.go
+++ b/test/integration/form/form_test.go
@@ -98,6 +98,11 @@ func TestResponseService_CancelSubmission(t *testing.T) {
 			validate: func(t *testing.T, err error, params params, queries *response.Queries) {
 				t.Helper()
 				require.ErrorIs(t, err, internal.ErrResponseNotOwned)
+
+				result, err := queries.Get(context.Background(), response.GetParams{ID: params.responseID, FormID: params.formID})
+				require.NoError(t, err)
+				require.Equal(t, response.ResponseProgressSubmitted, result.Progress)
+				require.True(t, result.SubmittedAt.Valid)
 			},
 		},
 	}

--- a/test/integration/form/form_test.go
+++ b/test/integration/form/form_test.go
@@ -1,0 +1,135 @@
+package form
+
+import (
+	"NYCU-SDC/core-system-backend/internal"
+	"NYCU-SDC/core-system-backend/internal/form"
+	"NYCU-SDC/core-system-backend/internal/form/response"
+	"NYCU-SDC/core-system-backend/internal/markdown"
+	"NYCU-SDC/core-system-backend/test/integration"
+	"NYCU-SDC/core-system-backend/test/testdata/dbbuilder"
+	formbuilder "NYCU-SDC/core-system-backend/test/testdata/dbbuilder/form"
+	userbuilder "NYCU-SDC/core-system-backend/test/testdata/dbbuilder/user"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	resourceManager, _, err := integration.GetOrInitResource()
+	if err != nil {
+		panic(err)
+	}
+
+	_, rollback, err := resourceManager.SetupPostgres()
+	if err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+
+	rollback()
+	resourceManager.Cleanup()
+
+	os.Exit(code)
+}
+
+func TestResponseService_CancelSubmission(t *testing.T) {
+	type params struct {
+		formID     uuid.UUID
+		ownerID    uuid.UUID
+		otherID    uuid.UUID
+		responseID uuid.UUID
+	}
+
+	testCases := []struct {
+		name      string
+		setup     func(t *testing.T, params *params, db dbbuilder.DBTX, responseService *response.Service, queries *response.Queries)
+		actUserID func(params params) uuid.UUID
+		validate  func(t *testing.T, err error, params params, queries *response.Queries)
+	}{
+		{
+			name: "reverts submitted response to draft",
+			setup: func(t *testing.T, params *params, db dbbuilder.DBTX, responseService *response.Service, queries *response.Queries) {
+				created, err := responseService.Create(context.Background(), params.formID, params.ownerID)
+				require.NoError(t, err)
+				params.responseID = created.ID
+
+				_, err = queries.UpdateSubmitted(context.Background(), created.ID)
+				require.NoError(t, err)
+			},
+			actUserID: func(params params) uuid.UUID { return params.ownerID },
+			validate: func(t *testing.T, err error, params params, queries *response.Queries) {
+				t.Helper()
+				require.NoError(t, err)
+
+				result, err := queries.Get(context.Background(), response.GetParams{ID: params.responseID, FormID: params.formID})
+				require.NoError(t, err)
+				require.Equal(t, response.ResponseProgressDraft, result.Progress)
+				require.False(t, result.SubmittedAt.Valid)
+			},
+		},
+		{
+			name: "rejects cancel when response is still draft",
+			setup: func(t *testing.T, params *params, db dbbuilder.DBTX, responseService *response.Service, queries *response.Queries) {
+				created, err := responseService.Create(context.Background(), params.formID, params.ownerID)
+				require.NoError(t, err)
+				params.responseID = created.ID
+			},
+			actUserID: func(params params) uuid.UUID { return params.ownerID },
+			validate: func(t *testing.T, err error, params params, queries *response.Queries) {
+				t.Helper()
+				require.ErrorIs(t, err, internal.ErrResponseNotSubmitted)
+			},
+		},
+		{
+			name: "rejects cancel from non-owner",
+			setup: func(t *testing.T, params *params, db dbbuilder.DBTX, responseService *response.Service, queries *response.Queries) {
+				created, err := responseService.Create(context.Background(), params.formID, params.ownerID)
+				require.NoError(t, err)
+				params.responseID = created.ID
+
+				_, err = queries.UpdateSubmitted(context.Background(), created.ID)
+				require.NoError(t, err)
+			},
+			actUserID: func(params params) uuid.UUID { return params.otherID },
+			validate: func(t *testing.T, err error, params params, queries *response.Queries) {
+				t.Helper()
+				require.ErrorIs(t, err, internal.ErrResponseNotOwned)
+			},
+		},
+	}
+
+	resourceManager, logger, err := integration.GetOrInitResource()
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, rollback, err := resourceManager.SetupPostgres()
+			require.NoError(t, err)
+			defer rollback()
+
+			owner := userbuilder.New(t, db).Create()
+			other := userbuilder.New(t, db).Create()
+			formRow := formbuilder.New(t, db).Create(formbuilder.WithLastEditor(owner.ID))
+
+			params := params{
+				formID:  formRow.ID,
+				ownerID: owner.ID,
+				otherID: other.ID,
+			}
+
+			formService := form.NewService(logger, db, markdown.NewService(logger))
+			responseService := response.NewService(logger, db, nil, nil, nil, formService, nil)
+			queries := response.New(db)
+
+			tc.setup(t, &params, db, responseService, queries)
+
+			err = responseService.CancelSubmission(context.Background(), params.responseID, tc.actUserID(params))
+
+			tc.validate(t, err, params, queries)
+		})
+	}
+}


### PR DESCRIPTION
## Type of changes
- Feature
- Test

## Purpose
- Add `POST /api/responses/{responseId}/cancel` to revert a submitted response to draft
- Add `ErrResponseNotSubmitted` error handling for invalid cancel attempts
- Add integration tests in `test/integration/form/form_test.go`
- Resolve issue CORE-370

## Additional Information

- Owner-only: non-owners receive `ErrResponseNotOwned`
- Cancel on draft response returns bad request via `ErrResponseNotSubmitted`
- Jira: https://clustron.atlassian.net/browse/CORE-370