### PR TITLE
[CORE-372] Fix Highlight Clear Not-Found Handling

### DIFF
--- a/internal/form/highlight/queries.sql
+++ b/internal/form/highlight/queries.sql
@@ -13,7 +13,7 @@ DO UPDATE SET
     updated_at = now()
 RETURNING *;
 
--- name: DeleteByFormID :exec
+-- name: DeleteByFormID :execrows
 DELETE FROM form_highlights
 WHERE form_id = $1;
 

--- a/internal/form/highlight/queries.sql.go
+++ b/internal/form/highlight/queries.sql.go
@@ -12,14 +12,17 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const deleteByFormID = `-- name: DeleteByFormID :exec
+const deleteByFormID = `-- name: DeleteByFormID :execrows
 DELETE FROM form_highlights
 WHERE form_id = $1
 `
 
-func (q *Queries) DeleteByFormID(ctx context.Context, formID uuid.UUID) error {
-	_, err := q.db.Exec(ctx, deleteByFormID, formID)
-	return err
+func (q *Queries) DeleteByFormID(ctx context.Context, formID uuid.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteByFormID, formID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const getByFormID = `-- name: GetByFormID :one

--- a/internal/form/highlight/service.go
+++ b/internal/form/highlight/service.go
@@ -229,6 +229,16 @@ func (s *Service) Clear(ctx context.Context, formID uuid.UUID) error {
 		return internal.ErrFormNotFound
 	}
 
+	_, err = s.queries.GetByFormID(traceCtx, formID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return internal.ErrHighlightNotFound
+	}
+	if err != nil {
+		err = databaseutil.WrapDBError(err, logger, "get form highlight")
+		span.RecordError(err)
+		return err
+	}
+
 	err = s.queries.DeleteByFormID(traceCtx, formID)
 	if err != nil {
 		err = databaseutil.WrapDBError(err, logger, "delete form highlight")

--- a/internal/form/highlight/service.go
+++ b/internal/form/highlight/service.go
@@ -23,7 +23,7 @@ import (
 type Querier interface {
 	GetByFormID(ctx context.Context, formID uuid.UUID) (FormHighlight, error)
 	UpsertByFormID(ctx context.Context, arg UpsertByFormIDParams) (FormHighlight, error)
-	DeleteByFormID(ctx context.Context, formID uuid.UUID) error
+	DeleteByFormID(ctx context.Context, formID uuid.UUID) (int64, error)
 	UpdateDisplayTitleByFormID(ctx context.Context, arg UpdateDisplayTitleByFormIDParams) (FormHighlight, error)
 	GetQuestionByFormIDAndQuestionID(ctx context.Context, arg GetQuestionByFormIDAndQuestionIDParams) (GetQuestionByFormIDAndQuestionIDRow, error)
 	ListAnswerValuesByQuestionID(ctx context.Context, questionID uuid.UUID) ([][]byte, error)
@@ -229,21 +229,14 @@ func (s *Service) Clear(ctx context.Context, formID uuid.UUID) error {
 		return internal.ErrFormNotFound
 	}
 
-	_, err = s.queries.GetByFormID(traceCtx, formID)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return internal.ErrHighlightNotFound
-	}
-	if err != nil {
-		err = databaseutil.WrapDBError(err, logger, "get form highlight")
-		span.RecordError(err)
-		return err
-	}
-
-	err = s.queries.DeleteByFormID(traceCtx, formID)
+	rowsAffected, err := s.queries.DeleteByFormID(traceCtx, formID)
 	if err != nil {
 		err = databaseutil.WrapDBError(err, logger, "delete form highlight")
 		span.RecordError(err)
 		return err
+	}
+	if rowsAffected == 0 {
+		return internal.ErrHighlightNotFound
 	}
 
 	return nil

--- a/internal/form/highlight/service_test.go
+++ b/internal/form/highlight/service_test.go
@@ -1,0 +1,119 @@
+package highlight
+
+import (
+	"NYCU-SDC/core-system-backend/internal"
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/zap"
+)
+
+type mockHighlightQuerier struct {
+	mock.Mock
+}
+
+func (m *mockHighlightQuerier) GetByFormID(ctx context.Context, formID uuid.UUID) (FormHighlight, error) {
+	args := m.Called(ctx, formID)
+	return args.Get(0).(FormHighlight), args.Error(1)
+}
+
+func (m *mockHighlightQuerier) UpsertByFormID(ctx context.Context, arg UpsertByFormIDParams) (FormHighlight, error) {
+	args := m.Called(ctx, arg)
+	return args.Get(0).(FormHighlight), args.Error(1)
+}
+
+func (m *mockHighlightQuerier) DeleteByFormID(ctx context.Context, formID uuid.UUID) error {
+	args := m.Called(ctx, formID)
+	return args.Error(0)
+}
+
+func (m *mockHighlightQuerier) UpdateDisplayTitleByFormID(ctx context.Context, arg UpdateDisplayTitleByFormIDParams) (FormHighlight, error) {
+	args := m.Called(ctx, arg)
+	return args.Get(0).(FormHighlight), args.Error(1)
+}
+
+func (m *mockHighlightQuerier) GetQuestionByFormIDAndQuestionID(ctx context.Context, arg GetQuestionByFormIDAndQuestionIDParams) (GetQuestionByFormIDAndQuestionIDRow, error) {
+	args := m.Called(ctx, arg)
+	return args.Get(0).(GetQuestionByFormIDAndQuestionIDRow), args.Error(1)
+}
+
+func (m *mockHighlightQuerier) ListAnswerValuesByQuestionID(ctx context.Context, questionID uuid.UUID) ([][]byte, error) {
+	args := m.Called(ctx, questionID)
+	return args.Get(0).([][]byte), args.Error(1)
+}
+
+type mockFormExistsStore struct {
+	mock.Mock
+}
+
+func (m *mockFormExistsStore) Exists(ctx context.Context, id uuid.UUID) (bool, error) {
+	args := m.Called(ctx, id)
+	return args.Bool(0), args.Error(1)
+}
+
+func TestService_Clear(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		setup    func(t *testing.T, formID uuid.UUID, queries *mockHighlightQuerier, formStore *mockFormExistsStore)
+		validate func(t *testing.T, err error)
+	}{
+		{
+			name: "returns not found when highlight does not exist",
+			setup: func(t *testing.T, formID uuid.UUID, queries *mockHighlightQuerier, formStore *mockFormExistsStore) {
+				t.Helper()
+				formStore.On("Exists", mock.Anything, formID).Return(true, nil).Once()
+				queries.On("GetByFormID", mock.Anything, formID).Return(FormHighlight{}, pgx.ErrNoRows).Once()
+			},
+			validate: func(t *testing.T, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, internal.ErrHighlightNotFound)
+			},
+		},
+		{
+			name: "deletes highlight when it exists",
+			setup: func(t *testing.T, formID uuid.UUID, queries *mockHighlightQuerier, formStore *mockFormExistsStore) {
+				t.Helper()
+				formStore.On("Exists", mock.Anything, formID).Return(true, nil).Once()
+				queries.On("GetByFormID", mock.Anything, formID).Return(FormHighlight{FormID: formID}, nil).Once()
+				queries.On("DeleteByFormID", mock.Anything, formID).Return(nil).Once()
+			},
+			validate: func(t *testing.T, err error) {
+				t.Helper()
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			formID := uuid.New()
+			queries := new(mockHighlightQuerier)
+			formStore := new(mockFormExistsStore)
+			tc.setup(t, formID, queries, formStore)
+
+			svc := &Service{
+				logger:    zap.NewNop(),
+				queries:   queries,
+				formStore: formStore,
+				tracer:    noop.NewTracerProvider().Tracer("test"),
+			}
+
+			err := svc.Clear(context.Background(), formID)
+			if tc.validate != nil {
+				tc.validate(t, err)
+			}
+
+			formStore.AssertExpectations(t)
+			queries.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/form/highlight/service_test.go
+++ b/internal/form/highlight/service_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -27,9 +26,9 @@ func (m *mockHighlightQuerier) UpsertByFormID(ctx context.Context, arg UpsertByF
 	return args.Get(0).(FormHighlight), args.Error(1)
 }
 
-func (m *mockHighlightQuerier) DeleteByFormID(ctx context.Context, formID uuid.UUID) error {
+func (m *mockHighlightQuerier) DeleteByFormID(ctx context.Context, formID uuid.UUID) (int64, error) {
 	args := m.Called(ctx, formID)
-	return args.Error(0)
+	return args.Get(0).(int64), args.Error(1)
 }
 
 func (m *mockHighlightQuerier) UpdateDisplayTitleByFormID(ctx context.Context, arg UpdateDisplayTitleByFormIDParams) (FormHighlight, error) {
@@ -69,7 +68,7 @@ func TestService_Clear(t *testing.T) {
 			setup: func(t *testing.T, formID uuid.UUID, queries *mockHighlightQuerier, formStore *mockFormExistsStore) {
 				t.Helper()
 				formStore.On("Exists", mock.Anything, formID).Return(true, nil).Once()
-				queries.On("GetByFormID", mock.Anything, formID).Return(FormHighlight{}, pgx.ErrNoRows).Once()
+				queries.On("DeleteByFormID", mock.Anything, formID).Return(int64(0), nil).Once()
 			},
 			validate: func(t *testing.T, err error) {
 				t.Helper()
@@ -81,8 +80,7 @@ func TestService_Clear(t *testing.T) {
 			setup: func(t *testing.T, formID uuid.UUID, queries *mockHighlightQuerier, formStore *mockFormExistsStore) {
 				t.Helper()
 				formStore.On("Exists", mock.Anything, formID).Return(true, nil).Once()
-				queries.On("GetByFormID", mock.Anything, formID).Return(FormHighlight{FormID: formID}, nil).Once()
-				queries.On("DeleteByFormID", mock.Anything, formID).Return(nil).Once()
+				queries.On("DeleteByFormID", mock.Anything, formID).Return(int64(1), nil).Once()
 			},
 			validate: func(t *testing.T, err error) {
 				t.Helper()


### PR DESCRIPTION
## Type of changes
- Fix
- Test

## Purpose
- Return `ErrHighlightNotFound` when clearing a highlight that does not exist
- Add unit tests for `highlight.Service.Clear` with mock dependencies
- Resolve issue CORE-372

## Additional Information

- Jira: https://clustron.atlassian.net/browse/CORE-372