### PR TITLE
Pin httpYac Action to v1.0.0 in Snapshot Workflow

### DIFF
--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -270,7 +270,7 @@ jobs:
 
       - name: Run httpYac Tests
         id: httpyac-tests
-        uses: NYCU-SDC/httpyac-action@feat/CORE-367-qa-test-selection
+        uses: NYCU-SDC/httpyac-action@v1.0.0
         with:
           scenarios-path: "./scenarios"
           changed-files-path: "./changed-files.json"
@@ -283,7 +283,7 @@ jobs:
       - name: List generated reports
         if: always()
         run: ls -lah reports/ || echo "No reports directory found"
-      
+
       - name: Upload test reports artifact
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Type of changes

- Chore

## Purpose

- After CORE-367 merged and `httpyac-action` v1.0.0 was released, stop pinning the snapshot QA workflow to a feature branch.
- Use the stable `v1.0.0` tag so CI references a released version instead of a temporary branch.

## Additional Information

- Updated `.github/workflows/snapshot.yaml` `ScenarioQA` job: `NYCU-SDC/httpyac-action@feat/CORE-367-qa-test-selection` → `@v1.0.0`.
- Release: https://github.com/NYCU-SDC/httpyac-action/releases/tag/v1.0.0